### PR TITLE
Add HTTP server with REST API and OpenAI-compatible endpoint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,8 @@ SRCS = main.c \
        qwen_tts_audio.c \
        qwen_tts_sampling.c \
        qwen_tts_tokenizer.c \
-       qwen_tts_safetensors.c
+       qwen_tts_safetensors.c \
+       qwen_tts_server.c
 
 OBJS = $(SRCS:.c=.o)
 TARGET = qwen_tts_bin
@@ -66,7 +67,7 @@ blas: $(TARGET)
 	$(CC) $(CFLAGS) -c -o $@ $<
 
 # Header dependencies
-main.o: main.c qwen_tts.h qwen_tts_audio.h qwen_tts_kernels.h
+main.o: main.c qwen_tts.h qwen_tts_audio.h qwen_tts_kernels.h qwen_tts_server.h
 qwen_tts.o: qwen_tts.c qwen_tts.h qwen_tts_kernels.h qwen_tts_safetensors.h qwen_tts_tokenizer.h qwen_tts_audio.h
 qwen_tts_talker.o: qwen_tts_talker.c qwen_tts.h qwen_tts_kernels.h
 qwen_tts_code_predictor.o: qwen_tts_code_predictor.c qwen_tts.h qwen_tts_kernels.h
@@ -79,6 +80,7 @@ qwen_tts_audio.o: qwen_tts_audio.c qwen_tts_audio.h
 qwen_tts_sampling.o: qwen_tts_sampling.c qwen_tts.h
 qwen_tts_tokenizer.o: qwen_tts_tokenizer.c qwen_tts_tokenizer.h
 qwen_tts_safetensors.o: qwen_tts_safetensors.c qwen_tts_safetensors.h
+qwen_tts_server.o: qwen_tts_server.c qwen_tts_server.h qwen_tts.h
 
 # Clean
 clean:
@@ -256,11 +258,39 @@ test-all: test-small test-large test-regression
 	@echo "  All tests passed (0.6B + 1.7B)"
 	@echo "========================================="
 
+# ── HTTP Server ──
+
+serve: $(TARGET)
+	./$(TARGET) -d $(MODEL_SMALL) --serve 8080
+
+test-serve: $(TARGET)
+	@echo "--- HTTP Server test ---"
+	@mkdir -p $(TEST_DIR)
+	@./$(TARGET) -d $(MODEL_SMALL) --serve 8090 &>/dev/null & SERVER_PID=$$!; \
+	 sleep 4; \
+	 echo "  Testing /v1/health..."; \
+	 HEALTH=$$(curl -s http://localhost:8090/v1/health); \
+	 if ! echo "$$HEALTH" | grep -q '"ok"'; then kill $$SERVER_PID 2>/dev/null; echo "FAIL: health check"; exit 1; fi; \
+	 echo "  Testing /v1/speakers..."; \
+	 SPEAKERS=$$(curl -s http://localhost:8090/v1/speakers); \
+	 if ! echo "$$SPEAKERS" | grep -q '"ryan"'; then kill $$SERVER_PID 2>/dev/null; echo "FAIL: speakers"; exit 1; fi; \
+	 echo "  Testing /v1/tts..."; \
+	 curl -s -X POST http://localhost:8090/v1/tts \
+	   -H "Content-Type: application/json" \
+	   -d '{"text":"Test.","speaker":"ryan"}' \
+	   -o $(TEST_DIR)/serve_test.wav; \
+	 if [ ! -f $(TEST_DIR)/serve_test.wav ]; then kill $$SERVER_PID 2>/dev/null; echo "FAIL: no WAV"; exit 1; fi; \
+	 WAV_SIZE=$$(stat -f%z $(TEST_DIR)/serve_test.wav 2>/dev/null || stat -c%s $(TEST_DIR)/serve_test.wav 2>/dev/null); \
+	 if [ "$$WAV_SIZE" -le 44 ]; then kill $$SERVER_PID 2>/dev/null; echo "FAIL: empty WAV"; exit 1; fi; \
+	 kill $$SERVER_PID 2>/dev/null; \
+	 echo "PASS: HTTP Server test"
+	@echo ""
+
 # Legacy aliases
 test-en: test-small-en
 test-it-ryan: test-small-it
 
-.PHONY: all help blas clean debug info \
+.PHONY: all help blas clean debug info serve test-serve \
         test-small test-small-en test-small-it test-small-vivian test-small-stream test-small-stdout \
         test-large test-large-en test-large-it test-large-config test-large-instruct \
         test-regression test-all test-en test-it-ryan

--- a/PLAN.md
+++ b/PLAN.md
@@ -119,12 +119,12 @@ lightweight, zero-dependency alternative.
 
 ### 3.1 Minimal HTTP Server
 
-- [ ] `[HIGH]` Implement embedded HTTP server (single-threaded, no external deps):
+- [x] `[HIGH]` Implement embedded HTTP server (single-threaded, no external deps):
   - Minimal HTTP/1.1 parser (enough for POST + headers)
   - Listen on configurable port: `--serve <port>` (default: 8080)
   - JSON request/response using simple hand-rolled parser
   - Model loaded once at startup, shared across requests
-- [ ] `[HIGH]` POST `/v1/tts` endpoint:
+- [x] `[HIGH]` POST `/v1/tts` endpoint:
   ```json
   {
     "text": "Hello world",
@@ -136,16 +136,16 @@ lightweight, zero-dependency alternative.
   }
   ```
   Response: WAV file (Content-Type: audio/wav)
-- [ ] `[MED]` POST `/v1/tts/stream` endpoint:
+- [x] `[MED]` POST `/v1/tts/stream` endpoint:
   - Same request format
-  - Response: chunked transfer encoding with raw PCM or WAV chunks
+  - Response: chunked transfer encoding with raw PCM
   - Client receives audio progressively as it's generated
-- [ ] `[MED]` GET `/v1/speakers` — list available speakers
-- [ ] `[MED]` GET `/v1/health` — status check
+- [x] `[MED]` GET `/v1/speakers` — list available speakers
+- [x] `[MED]` GET `/v1/health` — status check
 
 ### 3.2 OpenAI-Compatible API (optional)
 
-- [ ] `[LOW]` POST `/v1/audio/speech` (OpenAI TTS API format):
+- [x] `[LOW]` POST `/v1/audio/speech` (OpenAI TTS API format):
   ```json
   {
     "model": "qwen-tts",
@@ -160,8 +160,8 @@ lightweight, zero-dependency alternative.
 
 ### 3.3 Makefile Targets
 
-- [ ] `[MED]` `make serve` — build + start server on default port
-- [ ] `[MED]` `make test-serve` — start server, send test request, validate response
+- [x] `[MED]` `make serve` — build + start server on default port
+- [x] `[MED]` `make test-serve` — start server, send test request, validate response
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ make test-small       # Run 0.6B tests (English, Italian, multiple speakers)
 make test-large       # Run 1.7B tests (config check, English, Italian, instruct styles)
 make test-regression  # Cross-model regression checks (safetensors, config parsing)
 make test-all         # Run everything (0.6B + 1.7B + regression)
+make test-serve       # HTTP server integration test
+make serve            # Start HTTP server on port 8080
 ```
 
 ## Usage
@@ -178,6 +180,51 @@ Optional:
 > **Note:** Streaming decodes audio progressively every N frames (default: 10 = 0.8s).
 > First audio is available within ~1 second. `--stdout` outputs raw signed 16-bit
 > little-endian mono PCM at 24 kHz — pipe it to any audio player.
+
+### HTTP Server
+
+```bash
+# Start server (model loaded once, shared across requests)
+./qwen_tts -d qwen3-tts-0.6b --serve 8080
+
+# Generate speech (returns WAV)
+curl -X POST http://localhost:8080/v1/tts \
+  -H "Content-Type: application/json" \
+  -d '{"text":"Hello world","speaker":"ryan","language":"English"}' \
+  -o output.wav
+
+# Streaming (returns chunked raw PCM as it generates)
+curl -X POST http://localhost:8080/v1/tts/stream \
+  -H "Content-Type: application/json" \
+  -d '{"text":"Hello world","speaker":"ryan"}' \
+  -o output.raw
+
+# OpenAI-compatible endpoint (drop-in replacement)
+curl -X POST http://localhost:8080/v1/audio/speech \
+  -H "Content-Type: application/json" \
+  -d '{"input":"Hello world","voice":"ryan"}' \
+  -o output.wav
+
+# List speakers
+curl http://localhost:8080/v1/speakers
+
+# Health check
+curl http://localhost:8080/v1/health
+```
+
+The full request body for `/v1/tts`:
+```json
+{
+  "text": "Hello world",
+  "speaker": "ryan",
+  "language": "English",
+  "instruct": "Speak cheerfully",
+  "temperature": 0.9,
+  "top_k": 50,
+  "top_p": 1.0,
+  "rep_penalty": 1.05
+}
+```
 
 ## How It Works
 

--- a/main.c
+++ b/main.c
@@ -5,6 +5,7 @@
 #include "qwen_tts.h"
 #include "qwen_tts_audio.h"
 #include "qwen_tts_kernels.h"
+#include "qwen_tts_server.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -83,6 +84,7 @@ int main(int argc, char **argv) {
     int do_stream = 0;
     int do_stdout = 0;
     int stream_chunk = 10;
+    int serve_port = 0;  /* 0 = not serving */
 
     static struct option long_options[] = {
         {"model-dir",     required_argument, 0, 'd'},
@@ -100,6 +102,7 @@ int main(int argc, char **argv) {
         {"stream",        no_argument,       0, 1001},
         {"stdout",        no_argument,       0, 1002},
         {"stream-chunk",  required_argument, 0, 1003},
+        {"serve",         required_argument, 0, 1004},
         {"silent",        no_argument,       0, 'S'},
         {"debug",         no_argument,       0, 'D'},
         {"help",          no_argument,       0, 'h'},
@@ -124,6 +127,7 @@ int main(int argc, char **argv) {
             case 1001: do_stream = 1; break;
             case 1002: do_stdout = 1; do_stream = 1; break;  /* --stdout implies --stream */
             case 1003: stream_chunk = atoi(optarg); break;
+            case 1004: serve_port = atoi(optarg); break;
             case 'S': silent = 1; break;
             case 'D': debug = 1; break;
             case 'h':
@@ -146,14 +150,19 @@ int main(int argc, char **argv) {
                 fprintf(stderr, "  --stream                   Stream audio (decode during generation)\n");
                 fprintf(stderr, "  --stdout                   Output raw s16le PCM to stdout (implies --stream)\n");
                 fprintf(stderr, "  --stream-chunk <n>         Frames per stream chunk (default: 10)\n");
+                fprintf(stderr, "  --serve <port>             Start HTTP server on port\n");
                 fprintf(stderr, "  -S, --silent               Silent mode\n");
                 fprintf(stderr, "  -D, --debug                Debug mode\n");
                 return opt == 'h' ? 0 : 1;
         }
     }
 
-    if (!model_dir || !text) {
-        fprintf(stderr, "Error: --model-dir and --text are required\n");
+    if (!model_dir) {
+        fprintf(stderr, "Error: --model-dir is required\n");
+        return 1;
+    }
+    if (!text && serve_port <= 0) {
+        fprintf(stderr, "Error: --text or --serve is required\n");
         return 1;
     }
 
@@ -191,6 +200,13 @@ int main(int argc, char **argv) {
         } else {
             ctx->instruct = strdup(instruct);
         }
+    }
+
+    /* Server mode: start HTTP server and block */
+    if (serve_port > 0) {
+        int ret = qwen_tts_serve(ctx, serve_port);
+        qwen_tts_unload(ctx);
+        return ret;
     }
 
     /* Streaming setup */

--- a/qwen_tts_server.c
+++ b/qwen_tts_server.c
@@ -1,0 +1,462 @@
+/*
+ * qwen_tts_server.c - Minimal HTTP server for Qwen3-TTS
+ *
+ * Single-threaded, no external dependencies. Handles one request at a time.
+ * Endpoints:
+ *   POST /v1/tts          — generate speech, return WAV
+ *   POST /v1/tts/stream   — generate speech, return chunked raw PCM
+ *   GET  /v1/speakers     — list available speakers
+ *   GET  /v1/health       — health check
+ *   POST /v1/audio/speech — OpenAI-compatible TTS endpoint
+ */
+
+#include "qwen_tts_server.h"
+#include "qwen_tts.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <signal.h>
+#include <errno.h>
+
+/* ── Simple JSON helpers ─────────────────────────────────────────────── */
+
+/* Extract a string value for a key from JSON. Returns malloc'd string or NULL. */
+static char *json_extract_string(const char *json, const char *key) {
+    char pattern[256];
+    snprintf(pattern, sizeof(pattern), "\"%s\"", key);
+    const char *p = strstr(json, pattern);
+    if (!p) return NULL;
+    p += strlen(pattern);
+    while (*p == ' ' || *p == '\t' || *p == '\n' || *p == ':') p++;
+    if (*p != '"') return NULL;
+    p++;
+    const char *end = p;
+    while (*end && *end != '"') {
+        if (*end == '\\') end++;
+        end++;
+    }
+    int len = (int)(end - p);
+    char *result = (char *)malloc(len + 1);
+    memcpy(result, p, len);
+    result[len] = '\0';
+    return result;
+}
+
+/* Extract a numeric value for a key. Returns default if not found. */
+static double json_extract_number(const char *json, const char *key, double def) {
+    char pattern[256];
+    snprintf(pattern, sizeof(pattern), "\"%s\"", key);
+    const char *p = strstr(json, pattern);
+    if (!p) return def;
+    p += strlen(pattern);
+    while (*p == ' ' || *p == '\t' || *p == '\n' || *p == ':') p++;
+    if (*p == '"') return def; /* it's a string, not a number */
+    return atof(p);
+}
+
+/* ── HTTP helpers ────────────────────────────────────────────────────── */
+
+/* Read full HTTP request into buffer. Returns total bytes read, or -1. */
+static int read_request(int fd, char *buf, int buf_size) {
+    int total = 0;
+    int content_length = -1;
+    int header_end = -1;
+
+    while (total < buf_size - 1) {
+        int n = (int)read(fd, buf + total, buf_size - 1 - total);
+        if (n <= 0) break;
+        total += n;
+        buf[total] = '\0';
+
+        /* Look for end of headers */
+        if (header_end < 0) {
+            char *hend = strstr(buf, "\r\n\r\n");
+            if (hend) {
+                header_end = (int)(hend - buf) + 4;
+                /* Parse Content-Length */
+                char *cl = strcasestr(buf, "Content-Length:");
+                if (cl) content_length = atoi(cl + 15);
+                else content_length = 0;
+            }
+        }
+
+        /* Check if we have the full body */
+        if (header_end >= 0) {
+            int body_received = total - header_end;
+            if (body_received >= content_length) break;
+        }
+    }
+    return total;
+}
+
+/* Send HTTP response with headers + body */
+static void send_response(int fd, int status, const char *content_type,
+                          const void *body, int body_len) {
+    const char *status_text = (status == 200) ? "OK" :
+                              (status == 400) ? "Bad Request" :
+                              (status == 404) ? "Not Found" :
+                              (status == 405) ? "Method Not Allowed" :
+                              "Internal Server Error";
+    char header[512];
+    int hlen = snprintf(header, sizeof(header),
+        "HTTP/1.1 %d %s\r\n"
+        "Content-Type: %s\r\n"
+        "Content-Length: %d\r\n"
+        "Access-Control-Allow-Origin: *\r\n"
+        "Connection: close\r\n"
+        "\r\n",
+        status, status_text, content_type, body_len);
+    write(fd, header, hlen);
+    if (body && body_len > 0) write(fd, body, body_len);
+}
+
+static void send_json(int fd, int status, const char *json) {
+    send_response(fd, status, "application/json", json, (int)strlen(json));
+}
+
+static void send_error(int fd, int status, const char *msg) {
+    char json[512];
+    snprintf(json, sizeof(json), "{\"error\":\"%s\"}", msg);
+    send_json(fd, status, json);
+}
+
+/* ── Streaming response (chunked transfer encoding) ──────────────── */
+
+typedef struct {
+    int fd;
+    int total_samples;
+} stream_http_state_t;
+
+static void send_chunked_header(int fd) {
+    const char *header =
+        "HTTP/1.1 200 OK\r\n"
+        "Content-Type: audio/pcm\r\n"
+        "X-Sample-Rate: 24000\r\n"
+        "X-Sample-Format: s16le\r\n"
+        "X-Channels: 1\r\n"
+        "Transfer-Encoding: chunked\r\n"
+        "Access-Control-Allow-Origin: *\r\n"
+        "Connection: close\r\n"
+        "\r\n";
+    write(fd, header, strlen(header));
+}
+
+static int stream_http_callback(const float *samples, int n_samples, void *userdata) {
+    stream_http_state_t *st = (stream_http_state_t *)userdata;
+    /* Convert float to s16le */
+    int16_t *pcm = (int16_t *)malloc(n_samples * sizeof(int16_t));
+    for (int i = 0; i < n_samples; i++) {
+        float s = samples[i];
+        if (s < -1.0f) s = -1.0f;
+        if (s > 1.0f) s = 1.0f;
+        pcm[i] = (int16_t)(s * 32767);
+    }
+    /* Send as HTTP chunk: hex_size\r\n + data + \r\n */
+    int data_len = n_samples * 2;
+    char chunk_header[32];
+    int chlen = snprintf(chunk_header, sizeof(chunk_header), "%x\r\n", data_len);
+    write(st->fd, chunk_header, chlen);
+    write(st->fd, pcm, data_len);
+    write(st->fd, "\r\n", 2);
+    free(pcm);
+    st->total_samples += n_samples;
+    return 0;
+}
+
+static void send_chunked_end(int fd) {
+    write(fd, "0\r\n\r\n", 5);
+}
+
+/* ── WAV in-memory builder ───────────────────────────────────────────── */
+
+static void *build_wav(const float *samples, int n_samples, int *out_size) {
+    int sample_rate = QWEN_TTS_SAMPLE_RATE;
+    int bits = 16, channels = 1;
+    int data_size = n_samples * channels * (bits / 8);
+    int file_size = 36 + data_size;
+    int total = 44 + data_size;
+    char *wav = (char *)malloc(total);
+    char *p = wav;
+
+    /* RIFF header */
+    memcpy(p, "RIFF", 4); p += 4;
+    memcpy(p, &file_size, 4); p += 4;
+    memcpy(p, "WAVEfmt ", 8); p += 8;
+    int fmt_size = 16; memcpy(p, &fmt_size, 4); p += 4;
+    short audio_fmt = 1; memcpy(p, &audio_fmt, 2); p += 2;
+    short ch = channels; memcpy(p, &ch, 2); p += 2;
+    memcpy(p, &sample_rate, 4); p += 4;
+    int byte_rate = sample_rate * channels * (bits / 8);
+    memcpy(p, &byte_rate, 4); p += 4;
+    short block_align = channels * (bits / 8);
+    memcpy(p, &block_align, 2); p += 2;
+    short bps = bits; memcpy(p, &bps, 2); p += 2;
+    memcpy(p, "data", 4); p += 4;
+    memcpy(p, &data_size, 4); p += 4;
+
+    /* PCM samples */
+    int16_t *pcm = (int16_t *)p;
+    for (int i = 0; i < n_samples; i++) {
+        float s = samples[i];
+        if (s < -1.0f) s = -1.0f;
+        if (s > 1.0f) s = 1.0f;
+        pcm[i] = (int16_t)(s * 32767);
+    }
+
+    *out_size = total;
+    return wav;
+}
+
+/* ── Request handlers ────────────────────────────────────────────────── */
+
+static void handle_health(int fd) {
+    send_json(fd, 200, "{\"status\":\"ok\"}");
+}
+
+static void handle_speakers(int fd) {
+    const char *json =
+        "{\"speakers\":["
+        "{\"name\":\"ryan\",\"language\":\"English\",\"gender\":\"male\"},"
+        "{\"name\":\"aiden\",\"language\":\"English\",\"gender\":\"male\"},"
+        "{\"name\":\"vivian\",\"language\":\"Chinese\",\"gender\":\"female\"},"
+        "{\"name\":\"serena\",\"language\":\"Chinese\",\"gender\":\"female\"},"
+        "{\"name\":\"uncle_fu\",\"language\":\"Chinese\",\"gender\":\"male\"},"
+        "{\"name\":\"dylan\",\"language\":\"Chinese\",\"gender\":\"male\"},"
+        "{\"name\":\"eric\",\"language\":\"Chinese\",\"gender\":\"male\"},"
+        "{\"name\":\"ono_anna\",\"language\":\"Japanese\",\"gender\":\"female\"},"
+        "{\"name\":\"sohee\",\"language\":\"Korean\",\"gender\":\"female\"}"
+        "]}";
+    send_json(fd, 200, json);
+}
+
+/* Apply TTS params from JSON body to context. Returns text (malloc'd) or NULL on error. */
+static char *parse_tts_request(qwen_tts_ctx_t *ctx, const char *body) {
+    char *text = json_extract_string(body, "text");
+    if (!text) {
+        /* Try OpenAI-compatible "input" field */
+        text = json_extract_string(body, "input");
+    }
+    if (!text || text[0] == '\0') {
+        free(text);
+        return NULL;
+    }
+
+    char *speaker = json_extract_string(body, "speaker");
+    if (!speaker) speaker = json_extract_string(body, "voice");
+    if (speaker) {
+        int sid = qwen_tts_speaker_id(speaker);
+        if (sid >= 0) ctx->speaker_id = sid;
+        free(speaker);
+    }
+
+    char *language = json_extract_string(body, "language");
+    if (language) {
+        int lid = qwen_tts_language_id(language);
+        if (lid >= 0) ctx->language_id = lid;
+        free(language);
+    }
+
+    /* Instruct (1.7B only) */
+    free(ctx->instruct);
+    ctx->instruct = json_extract_string(body, "instruct");
+
+    /* Sampling params */
+    ctx->temperature = (float)json_extract_number(body, "temperature", ctx->temperature);
+    ctx->top_k = (int)json_extract_number(body, "top_k", ctx->top_k);
+    ctx->top_p = (float)json_extract_number(body, "top_p", ctx->top_p);
+    ctx->rep_penalty = (float)json_extract_number(body, "rep_penalty", ctx->rep_penalty);
+
+    return text;
+}
+
+static void handle_tts(qwen_tts_ctx_t *ctx, int fd, const char *body) {
+    char *text = parse_tts_request(ctx, body);
+    if (!text) {
+        send_error(fd, 400, "missing 'text' field");
+        return;
+    }
+
+    fprintf(stderr, "[HTTP] TTS: \"%s\"\n", text);
+
+    /* Disable streaming for this path — full decode */
+    ctx->stream = 0;
+    ctx->audio_cb = NULL;
+
+    float *audio = NULL;
+    int n_samples = 0;
+    if (qwen_tts_generate(ctx, text, &audio, &n_samples) != 0 || !audio || n_samples == 0) {
+        send_error(fd, 500, "generation failed");
+        free(text);
+        free(audio);
+        return;
+    }
+
+    /* Build WAV in memory and send */
+    int wav_size = 0;
+    void *wav = build_wav(audio, n_samples, &wav_size);
+    free(audio);
+    free(text);
+
+    send_response(fd, 200, "audio/wav", wav, wav_size);
+    free(wav);
+
+    fprintf(stderr, "[HTTP] Sent %d bytes WAV (%.2fs audio)\n",
+            wav_size, (float)n_samples / QWEN_TTS_SAMPLE_RATE);
+}
+
+static void handle_tts_stream(qwen_tts_ctx_t *ctx, int fd, const char *body) {
+    char *text = parse_tts_request(ctx, body);
+    if (!text) {
+        send_error(fd, 400, "missing 'text' field");
+        return;
+    }
+
+    fprintf(stderr, "[HTTP] TTS stream: \"%s\"\n", text);
+
+    /* Set up streaming */
+    stream_http_state_t state = { .fd = fd, .total_samples = 0 };
+    ctx->stream = 1;
+    ctx->stream_chunk_frames = 10;
+    qwen_tts_set_audio_callback(ctx, stream_http_callback, &state);
+
+    /* Send chunked response header */
+    send_chunked_header(fd);
+
+    float *audio = NULL;
+    int n_samples = 0;
+    qwen_tts_generate(ctx, text, &audio, &n_samples);
+    free(audio);
+    free(text);
+
+    /* Terminate chunked encoding */
+    send_chunked_end(fd);
+
+    /* Clean up streaming state */
+    ctx->stream = 0;
+    ctx->audio_cb = NULL;
+
+    fprintf(stderr, "[HTTP] Streamed %d samples (%.2fs audio)\n",
+            state.total_samples, (float)state.total_samples / QWEN_TTS_SAMPLE_RATE);
+}
+
+/* ── Main server loop ────────────────────────────────────────────────── */
+
+static volatile int server_running = 1;
+
+static void sigint_handler(int sig) {
+    (void)sig;
+    server_running = 0;
+}
+
+int qwen_tts_serve(qwen_tts_ctx_t *ctx, int port) {
+    int server_fd = socket(AF_INET, SOCK_STREAM, 0);
+    if (server_fd < 0) { perror("socket"); return -1; }
+
+    int opt = 1;
+    setsockopt(server_fd, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
+
+    struct sockaddr_in addr = {
+        .sin_family = AF_INET,
+        .sin_addr.s_addr = INADDR_ANY,
+        .sin_port = htons(port)
+    };
+
+    if (bind(server_fd, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
+        perror("bind");
+        close(server_fd);
+        return -1;
+    }
+
+    if (listen(server_fd, 5) < 0) {
+        perror("listen");
+        close(server_fd);
+        return -1;
+    }
+
+    signal(SIGINT, sigint_handler);
+    signal(SIGPIPE, SIG_IGN);
+
+    fprintf(stderr, "Server listening on http://0.0.0.0:%d\n", port);
+    fprintf(stderr, "Endpoints:\n");
+    fprintf(stderr, "  POST /v1/tts          — generate speech (returns WAV)\n");
+    fprintf(stderr, "  POST /v1/tts/stream   — generate speech (chunked PCM stream)\n");
+    fprintf(stderr, "  POST /v1/audio/speech — OpenAI-compatible TTS\n");
+    fprintf(stderr, "  GET  /v1/speakers     — list speakers\n");
+    fprintf(stderr, "  GET  /v1/health       — health check\n");
+    fprintf(stderr, "Press Ctrl+C to stop.\n\n");
+
+    /* Suppress model output during request handling */
+    ctx->silent = 1;
+
+    while (server_running) {
+        struct sockaddr_in client_addr;
+        socklen_t client_len = sizeof(client_addr);
+        int client_fd = accept(server_fd, (struct sockaddr *)&client_addr, &client_len);
+        if (client_fd < 0) {
+            if (errno == EINTR) continue;
+            perror("accept");
+            continue;
+        }
+
+        /* Read request */
+        char *buf = (char *)malloc(1024 * 1024); /* 1MB max request */
+        int total = read_request(client_fd, buf, 1024 * 1024);
+        if (total <= 0) { free(buf); close(client_fd); continue; }
+
+        /* Parse method and path */
+        char method[16] = {0}, path[256] = {0};
+        sscanf(buf, "%15s %255s", method, path);
+
+        /* Find body (after \r\n\r\n) */
+        const char *body = strstr(buf, "\r\n\r\n");
+        if (body) body += 4;
+        else body = "";
+
+        char *client_ip = inet_ntoa(client_addr.sin_addr);
+        fprintf(stderr, "[HTTP] %s %s %s from %s\n", method, path,
+                (strcmp(method, "POST") == 0 && body[0]) ? "(has body)" : "", client_ip);
+
+        /* Handle CORS preflight */
+        if (strcmp(method, "OPTIONS") == 0) {
+            const char *cors =
+                "HTTP/1.1 204 No Content\r\n"
+                "Access-Control-Allow-Origin: *\r\n"
+                "Access-Control-Allow-Methods: GET, POST, OPTIONS\r\n"
+                "Access-Control-Allow-Headers: Content-Type\r\n"
+                "Connection: close\r\n\r\n";
+            write(client_fd, cors, strlen(cors));
+        }
+        /* Route requests */
+        else if (strcmp(path, "/v1/health") == 0 && strcmp(method, "GET") == 0) {
+            handle_health(client_fd);
+        }
+        else if (strcmp(path, "/v1/speakers") == 0 && strcmp(method, "GET") == 0) {
+            handle_speakers(client_fd);
+        }
+        else if (strcmp(path, "/v1/tts") == 0 && strcmp(method, "POST") == 0) {
+            handle_tts(ctx, client_fd, body);
+        }
+        else if (strcmp(path, "/v1/tts/stream") == 0 && strcmp(method, "POST") == 0) {
+            handle_tts_stream(ctx, client_fd, body);
+        }
+        else if (strcmp(path, "/v1/audio/speech") == 0 && strcmp(method, "POST") == 0) {
+            /* OpenAI-compatible: same as /v1/tts */
+            handle_tts(ctx, client_fd, body);
+        }
+        else {
+            send_error(client_fd, 404, "not found");
+        }
+
+        free(buf);
+        close(client_fd);
+    }
+
+    close(server_fd);
+    fprintf(stderr, "\nServer stopped.\n");
+    return 0;
+}

--- a/qwen_tts_server.h
+++ b/qwen_tts_server.h
@@ -1,0 +1,10 @@
+/* qwen_tts_server.h - Minimal HTTP server for Qwen3-TTS */
+#ifndef QWEN_TTS_SERVER_H
+#define QWEN_TTS_SERVER_H
+
+#include "qwen_tts.h"
+
+/* Start HTTP server. Blocks until killed. Returns 0 on clean shutdown, -1 on error. */
+int qwen_tts_serve(qwen_tts_ctx_t *ctx, int port);
+
+#endif /* QWEN_TTS_SERVER_H */


### PR DESCRIPTION
## Summary

Minimal embedded HTTP server — no external dependencies, single-threaded, ~400 lines of C.

- **`--serve <port>`**: Start HTTP server (model loaded once, shared across requests)
- **POST `/v1/tts`**: Generate speech → WAV response
- **POST `/v1/tts/stream`**: Chunked transfer encoding with raw PCM (streams during generation)
- **POST `/v1/audio/speech`**: OpenAI TTS API compatible (accepts `input`/`voice` fields)
- **GET `/v1/speakers`**: List available speakers with language/gender
- **GET `/v1/health`**: Health check
- CORS support for browser clients
- `make serve` and `make test-serve` targets

## Test plan

- [x] `make test-serve` passes (health, speakers, TTS generation)
- [x] `make test-small-en` still passes (non-server mode unchanged)
- [x] `/v1/tts` returns valid WAV that plays correctly
- [x] `/v1/tts/stream` returns chunked PCM (verified via ffmpeg conversion)
- [x] `/v1/audio/speech` works with OpenAI-format request body
- [x] Server handles CORS preflight (OPTIONS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)