### PR TITLE
Add VoiceDesign: create voices from text descriptions

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -242,13 +242,13 @@ timbre from the description instead of using a preset speaker.
 
 ### Tasks
 
-- [ ] `[MED]` Extend `download_model.sh` for VoiceDesign model:
+- [x] `[MED]` Extend `download_model.sh` for VoiceDesign model:
   - `Qwen/Qwen3-TTS-12Hz-1.7B-VoiceDesign`
-- [ ] `[MED]` Implement VoiceDesign prompt format:
-  - Uses `generate_voice_design(text, language, instruct)` in Python
+- [x] `[MED]` Implement VoiceDesign prompt format:
+  - Same as CustomVoice but without speaker token in codec prefix
+  - Auto-detected from config (empty `spk_id`)
   - Instruct describes the desired voice characteristics
-  - No speaker ID needed — the model creates a voice from the description
-- [ ] `[MED]` CLI: `--voice-design <description>` (mutually exclusive with `--speaker`)
+- [x] `[MED]` CLI: `--voice-design` flag (auto-detected, or force with flag)
 - [ ] `[LOW]` Add `make test-voice-design` target
 
 ---

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ git clone https://github.com/gabriele-mastrapasqua/qwen3-tts.git
 cd qwen3-tts
 make blas
 
-# Download a model (interactive: small=0.6B, large=1.7B)
+# Download a model (interactive: small=0.6B, large=1.7B, voice-design)
 ./download_model.sh
 
 # Synthesize speech
@@ -116,6 +116,7 @@ Optional:
   --max-tokens <n>           Max audio tokens (default: 8192)
   --max-duration <secs>      Max audio duration in seconds
   --seed <n>                 Random seed for reproducible output
+  --voice-design             VoiceDesign mode (create voice from --instruct)
   -j, --threads <n>          Worker threads (default: 4)
   --stream                   Stream audio (decode chunks during generation)
   --stdout                   Output raw s16le PCM to stdout (implies --stream)
@@ -160,6 +161,34 @@ Optional:
 
 > **Note:** The `--instruct` flag only works with the 1.7B model. The 0.6B model does not
 > support style control and will ignore the instruction.
+
+### VoiceDesign
+
+Create entirely new voices from natural language descriptions using the VoiceDesign model:
+
+```bash
+# Download the VoiceDesign model
+./download_model.sh --model voice-design
+
+# Deep British male
+./qwen_tts -d qwen3-tts-voice-design -l English \
+    --instruct "A deep male voice with a British accent, speaking slowly and calmly" \
+    --text "Hello, this is a test of the voice design system." -o british.wav
+
+# Young energetic female
+./qwen_tts -d qwen3-tts-voice-design -l English \
+    --instruct "Young energetic female, cheerful and fast-paced" \
+    --text "Oh my gosh, this is so exciting!" -o cheerful.wav
+
+# Chinese loli voice
+./qwen_tts -d qwen3-tts-voice-design -l Chinese \
+    --instruct "萝莉女声，撒娇稚嫩" \
+    --text "你好，这是一个语音设计的测试。" -o loli.wav
+```
+
+> **Note:** VoiceDesign requires the `Qwen3-TTS-12Hz-1.7B-VoiceDesign` model.
+> The model type is auto-detected from the config. `--instruct` is required
+> to describe the desired voice. No `--speaker` is needed.
 
 ### Streaming
 

--- a/download_model.sh
+++ b/download_model.sh
@@ -5,9 +5,10 @@
 #   ./download_model.sh
 #   ./download_model.sh --model small
 #   ./download_model.sh --model large --dir my-model-dir
+#   ./download_model.sh --model voice-design
 #
 # Options:
-#   --model small|large   Choose 0.6B (small) or 1.7B (large)
+#   --model small|large|voice-design   Choose 0.6B, 1.7B, or VoiceDesign
 #   --dir DIR             Override output directory
 
 set -e
@@ -45,9 +46,10 @@ choose_model_interactive() {
     echo "Select model size to download:"
     echo "  1) small (Qwen3-TTS-12Hz-0.6B-CustomVoice)"
     echo "  2) large (Qwen3-TTS-12Hz-1.7B-CustomVoice)"
+    echo "  3) voice-design (Qwen3-TTS-12Hz-1.7B-VoiceDesign)"
     echo ""
     while true; do
-        read -r -p "Enter choice [1/2]: " ans
+        read -r -p "Enter choice [1/2/3]: " ans
         case "$ans" in
             1|small|Small|SMALL)
                 MODEL_CHOICE="small"
@@ -57,8 +59,12 @@ choose_model_interactive() {
                 MODEL_CHOICE="large"
                 return
                 ;;
+            3|voice-design|VoiceDesign)
+                MODEL_CHOICE="voice-design"
+                return
+                ;;
             *)
-                echo "Please choose 1 (small) or 2 (large)."
+                echo "Please choose 1 (small), 2 (large), or 3 (voice-design)."
                 ;;
         esac
     done
@@ -107,9 +113,28 @@ case "$MODEL_CHOICE" in
             "preprocessor_config.json"
         )
         ;;
+    voice-design|voicedesign|VoiceDesign)
+        MODEL_ID="Qwen/Qwen3-TTS-12Hz-1.7B-VoiceDesign"
+        if [[ -z "$MODEL_DIR" ]]; then MODEL_DIR="qwen3-tts-voice-design"; fi
+        FILES=(
+            "config.json"
+            "generation_config.json"
+            "tokenizer_config.json"
+            "preprocessor_config.json"
+            "model.safetensors"
+            "vocab.json"
+            "merges.txt"
+        )
+        SPEECH_TOKENIZER_FILES=(
+            "config.json"
+            "configuration.json"
+            "model.safetensors"
+            "preprocessor_config.json"
+        )
+        ;;
     *)
         echo "Invalid --model value: $MODEL_CHOICE"
-        echo "Use: --model small or --model large"
+        echo "Use: --model small, --model large, or --model voice-design"
         exit 1
         ;;
 esac

--- a/main.c
+++ b/main.c
@@ -87,6 +87,7 @@ int main(int argc, char **argv) {
     int serve_port = 0;  /* 0 = not serving */
     int seed = -1;       /* -1 = use time-based seed */
     float max_duration = 0;  /* 0 = no limit */
+    int voice_design = 0;
 
     static struct option long_options[] = {
         {"model-dir",     required_argument, 0, 'd'},
@@ -107,6 +108,7 @@ int main(int argc, char **argv) {
         {"serve",         required_argument, 0, 1004},
         {"seed",          required_argument, 0, 1005},
         {"max-duration",  required_argument, 0, 1006},
+        {"voice-design",  no_argument,       0, 1007},
         {"silent",        no_argument,       0, 'S'},
         {"debug",         no_argument,       0, 'D'},
         {"help",          no_argument,       0, 'h'},
@@ -134,6 +136,7 @@ int main(int argc, char **argv) {
             case 1004: serve_port = atoi(optarg); break;
             case 1005: seed = atoi(optarg); break;
             case 1006: max_duration = (float)atof(optarg); break;
+            case 1007: voice_design = 1; break;
             case 'S': silent = 1; break;
             case 'D': debug = 1; break;
             case 'h':
@@ -159,6 +162,7 @@ int main(int argc, char **argv) {
                 fprintf(stderr, "  --serve <port>             Start HTTP server on port\n");
                 fprintf(stderr, "  --seed <n>                 Random seed (default: time-based)\n");
                 fprintf(stderr, "  --max-duration <secs>      Max audio duration in seconds\n");
+                fprintf(stderr, "  --voice-design             VoiceDesign mode (create voice from --instruct)\n");
                 fprintf(stderr, "  -S, --silent               Silent mode\n");
                 fprintf(stderr, "  -D, --debug                Debug mode\n");
                 return opt == 'h' ? 0 : 1;
@@ -204,6 +208,7 @@ int main(int argc, char **argv) {
     if (language) ctx->language_id = qwen_tts_language_id(language);
     if (seed >= 0) ctx->seed = (uint32_t)seed;
     if (max_duration > 0) ctx->max_tokens = (int)(max_duration * 12.5f);
+    if (voice_design) ctx->voice_design = 1;
     if (instruct) {
         if (ctx->config.hidden_size < 2048) {
             fprintf(stderr, "Warning: --instruct is only supported on 1.7B model (ignored)\n");

--- a/qwen_tts.c
+++ b/qwen_tts.c
@@ -263,12 +263,36 @@ qwen_tts_ctx_t *qwen_tts_load(const char *model_dir) {
     }
     
     qwen_tts_config_t *c = &ctx->config;
+
+    /* Auto-detect VoiceDesign model: check if spk_id is empty in config */
+    if (!ctx->voice_design) {
+        char cfg_path[1024];
+        snprintf(cfg_path, sizeof(cfg_path), "%s/config.json", ctx->model_dir);
+        long cfg_len;
+        char *cfg_raw = read_file(cfg_path, &cfg_len);
+        if (cfg_raw) {
+            /* VoiceDesign has "spk_id": {} (empty object) */
+            const char *spk = strstr(cfg_raw, "\"spk_id\"");
+            if (spk) {
+                const char *p = spk + 8;
+                while (*p == ' ' || *p == ':' || *p == '\t' || *p == '\n') p++;
+                if (*p == '{') {
+                    p++;
+                    while (*p == ' ' || *p == '\t' || *p == '\n') p++;
+                    if (*p == '}') ctx->voice_design = 1;
+                }
+            }
+            free(cfg_raw);
+        }
+    }
+
     if (!ctx->silent) {
         fprintf(stderr, "Config: hidden=%d text_hidden=%d layers=%d heads=%d/%d head_dim=%d inter=%d\n",
                 c->hidden_size, c->text_hidden_size, c->num_layers, c->num_heads, c->num_kv_heads, c->head_dim, c->intermediate_size);
         fprintf(stderr, "  Code Predictor: hidden=%d layers=%d heads=%d head_dim=%d\n",
                 c->cp_hidden_size, c->cp_num_layers, c->cp_num_heads, c->cp_head_dim);
         fprintf(stderr, "  Codec: vocab=%d codebooks=%d entries=%d\n", c->codec_vocab_size, c->dec_num_quantizers, c->codebook_size);
+        if (ctx->voice_design) fprintf(stderr, "  Mode: VoiceDesign (no preset speakers)\n");
     }
 
     /* Load safetensors using qwen-asr loader (mmap-based, working) */
@@ -440,8 +464,10 @@ int qwen_tts_generate(qwen_tts_ctx_t *ctx, const char *text, float **out_samples
     }
 
     /* Build codec-side prefix:
-     * With language: [THINK, THINK_BOS, language_id, THINK_EOS, speaker, PAD, BOS]
-     * Without language: [NO_THINK, THINK_BOS, THINK_EOS, speaker, PAD, BOS]
+     * CustomVoice with language: [THINK, THINK_BOS, language_id, THINK_EOS, speaker, PAD, BOS]
+     * CustomVoice without language: [NO_THINK, THINK_BOS, THINK_EOS, speaker, PAD, BOS]
+     * VoiceDesign with language: [THINK, THINK_BOS, language_id, THINK_EOS, PAD, BOS]
+     * VoiceDesign without language: [NO_THINK, THINK_BOS, THINK_EOS, PAD, BOS]
      */
     int codec_tokens[16];
     int codec_len = 0;
@@ -455,7 +481,10 @@ int qwen_tts_generate(qwen_tts_ctx_t *ctx, const char *text, float **out_samples
         codec_tokens[codec_len++] = QWEN_TTS_CODEC_THINK_BOS;
         codec_tokens[codec_len++] = QWEN_TTS_CODEC_THINK_EOS;
     }
-    codec_tokens[codec_len++] = ctx->speaker_id;
+    /* VoiceDesign: no speaker token (voice created from instruct description) */
+    if (!ctx->voice_design) {
+        codec_tokens[codec_len++] = ctx->speaker_id;
+    }
     codec_tokens[codec_len++] = QWEN_TTS_CODEC_PAD;
     codec_tokens[codec_len++] = QWEN_TTS_CODEC_BOS;
 

--- a/qwen_tts.h
+++ b/qwen_tts.h
@@ -310,8 +310,11 @@ typedef struct {
     int speaker_id;
     int language_id;
 
-    /* Instruct text (style/emotion control, 1.7B only) */
+    /* Instruct text (style/emotion control, 1.7B only; required for VoiceDesign) */
     char *instruct;
+
+    /* VoiceDesign mode (no preset speakers, voice created from instruct) */
+    int voice_design;
 
     /* Streaming */
     int stream;                  /* Enable streaming (decode chunks during generation) */

--- a/qwen_tts_server.c
+++ b/qwen_tts_server.c
@@ -265,6 +265,13 @@ static char *parse_tts_request(qwen_tts_ctx_t *ctx, const char *body) {
     free(ctx->instruct);
     ctx->instruct = json_extract_string(body, "instruct");
 
+    /* Voice design mode */
+    char *vd = json_extract_string(body, "voice_design");
+    if (vd) {
+        if (strcmp(vd, "true") == 0 || strcmp(vd, "1") == 0) ctx->voice_design = 1;
+        free(vd);
+    }
+
     /* Sampling params */
     ctx->temperature = (float)json_extract_number(body, "temperature", ctx->temperature);
     ctx->top_k = (int)json_extract_number(body, "top_k", ctx->top_k);


### PR DESCRIPTION
## Summary

Support for the `Qwen3-TTS-12Hz-1.7B-VoiceDesign` model — creates entirely new voices from natural language descriptions.

- **Auto-detection**: Model type detected from config (`spk_id: {}` → VoiceDesign)
- **Prompt change**: Omits speaker token from codec prefix (only diff from CustomVoice)
- **`--voice-design`** flag (also auto-detected from model)
- **`download_model.sh --model voice-design`**
- **HTTP server**: `voice_design` field in JSON request body

Tested with:
- Deep British male voice
- Young energetic female voice  
- Chinese loli voice (萝莉女声)

## Test plan
- [x] VoiceDesign model auto-detected (`Mode: VoiceDesign`)
- [x] Generates valid audio with voice descriptions
- [x] Existing 0.6B tests still pass (test-small-en)
- [x] Build clean, no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)