### PR TITLE
Vectorized snake activation kernel (Accelerate/NEON)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -278,7 +278,10 @@ timbre from the description instead of using a preset speaker.
 ### 7.2 Further CPU Optimizations
 
 - [ ] `[MED]` Profile 1.7B model bottlenecks (Talker prefill is slow: ~4s for 24 tokens)
-- [ ] `[MED]` NEON/AVX snake activation kernels
+- [x] `[MED]` NEON/AVX snake activation kernels
+  - macOS: Accelerate vvsinf + vDSP for vectorized sin/mul/add
+  - ARM NEON: 4-wide SIMD with scalar sinf per lane + fma
+  - Generic fallback for non-SIMD platforms
 - [ ] `[LOW]` Persistent BF16 KV cache (avoid bf16→f32 conversion)
 
 ---

--- a/qwen_tts_kernels.c
+++ b/qwen_tts_kernels.c
@@ -485,6 +485,69 @@ void qwen_round_bf16(float *x, int n) {
 }
 
 /* ========================================================================
+ * Snake activation: x += (1/exp(beta)) * sin²(exp(alpha) * x)
+ * ======================================================================== */
+
+void qwen_snake_activation(float *data, int channels, int length,
+                            const float *log_alpha, const float *log_beta) {
+    for (int c = 0; c < channels; c++) {
+        float a = expf(log_alpha[c]);
+        float inv_b = expf(-log_beta[c]);
+        float *row = data + (int64_t)c * length;
+
+#if defined(__APPLE__) && defined(USE_BLAS)
+        /* Use Accelerate vForce for vectorized sin — fast on Apple Silicon */
+        {
+            int n = length;
+            float *temp = (float *)malloc(n * sizeof(float));
+
+            /* temp = a * row */
+            vDSP_vsmul(row, 1, &a, temp, 1, n);
+
+            /* temp = sin(temp) */
+            vvsinf(temp, temp, &n);
+
+            /* temp = temp * temp (sin²) */
+            vDSP_vsq(temp, 1, temp, 1, n);
+
+            /* row += inv_b * temp */
+            vDSP_vsma(temp, 1, &inv_b, row, 1, row, 1, n);
+
+            free(temp);
+        }
+#elif defined(__ARM_NEON)
+        {
+            float32x4_t va = vdupq_n_f32(a);
+            float32x4_t vinv_b = vdupq_n_f32(inv_b);
+            int t = 0;
+            for (; t + 3 < length; t += 4) {
+                float32x4_t x = vld1q_f32(row + t);
+                float32x4_t ax = vmulq_f32(va, x);
+                /* Scalar sinf for each lane (no NEON intrinsic for sin) */
+                float ax_s[4];
+                vst1q_f32(ax_s, ax);
+                float s_arr[4] = { sinf(ax_s[0]), sinf(ax_s[1]),
+                                   sinf(ax_s[2]), sinf(ax_s[3]) };
+                float32x4_t s = vld1q_f32(s_arr);
+                float32x4_t s2 = vmulq_f32(s, s);
+                x = vfmaq_f32(x, vinv_b, s2);
+                vst1q_f32(row + t, x);
+            }
+            for (; t < length; t++) {
+                float s = sinf(a * row[t]);
+                row[t] += inv_b * s * s;
+            }
+        }
+#else
+        for (int t = 0; t < length; t++) {
+            float s = sinf(a * row[t]);
+            row[t] += inv_b * s * s;
+        }
+#endif
+    }
+}
+
+/* ========================================================================
  * RoPE - Interleaved (already defined in talker.c, stub here)
  * ======================================================================== */
 

--- a/qwen_tts_kernels.h
+++ b/qwen_tts_kernels.h
@@ -93,6 +93,12 @@ void qwen_vec_scale_inplace(float *y, float s, int n);
 /* bf16 rounding */
 void qwen_round_bf16(float *x, int n);
 
+/* Snake activation: x += (1/exp(beta)) * sin²(exp(alpha) * x)
+ * Applied per-channel to channel-first data [channels, length].
+ * log_alpha/log_beta are per-channel params in LOG SPACE. */
+void qwen_snake_activation(float *data, int channels, int length,
+                            const float *log_alpha, const float *log_beta);
+
 /* ========================================================================
  * Argmax / Sampling
  * ======================================================================== */

--- a/qwen_tts_speech_decoder.c
+++ b/qwen_tts_speech_decoder.c
@@ -57,21 +57,9 @@ static int conv_transpose1d_out_len(int in_len, int kernel, int stride) {
     return (in_len - 1) * stride + kernel - (kernel - stride);
 }
 
-/* Snake activation: x + (1/exp(beta)) * sin²(exp(alpha) * x)
- * Alpha and beta are stored in LOG SPACE.
- * Applied per-channel to channel-first data [channels, length]. */
-static void snake_activation(float *data, int channels, int length,
-                              const float *log_alpha, const float *log_beta) {
-    for (int c = 0; c < channels; c++) {
-        float a = expf(log_alpha[c]);
-        float inv_b = expf(-log_beta[c]);
-        float *row = data + (int64_t)c * length;
-        for (int t = 0; t < length; t++) {
-            float s = sinf(a * row[t]);
-            row[t] += inv_b * s * s;
-        }
-    }
-}
+/* Snake activation dispatched through qwen_snake_activation() kernel
+ * (NEON/Accelerate-optimized in qwen_tts_kernels.c) */
+#define snake_activation qwen_snake_activation
 
 #ifndef USE_BLAS
 /* Naive causal Conv1d: [out_ch, in_ch, kernel], pad_left=(kernel-1)*dilation */


### PR DESCRIPTION
## Summary
- Snake activation moved from scalar loop to optimized kernel in qwen_tts_kernels.c
- macOS: Accelerate vvsinf + vDSP (fully vectorized, no scalar sinf calls)
- ARM NEON: 4-wide SIMD with fma
- Generic fallback for other platforms

## Test plan
- [x] `make test-small` all tests pass
- [x] Output verified correct with seed 42

🤖 Generated with [Claude Code](https://claude.com/claude-code)