### PR TITLE
ARM perf: SDOT Q4_0 matvec, spin-pool, int8 decoder convs, exact streaming conv state (stream RTF 2.2 -> 1.3 on 4-core Neoverse-N1)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -119,6 +119,25 @@ Two structural facts drive the map:
   help. Reverted per "no complexity for tiny wins." Re-try only if x86/AVX2 measurement shows x-loads
   matter there (the AVX2 twin would need the rented box). The real q4 lever, if any, is a DECODE
   rework (e.g. int8-x + SDOT on decoded nibbles), not x-load sharing.
+- [x] **WON (2026-07-03, `feature/q4-sdot`) — q4_0 DECODE rework: SDOT on decoded nibbles.** Exactly
+  the lever predicted above. Two changes: (1) `qwen_quantize_bf16_to_q4_0` now packs nibbles
+  **DEINTERLEAVED** (lo nibbles = weights 0-15, hi = 16-31) so `vand`/`vshr` yield two `int8x16` in
+  natural order — no zip; (2) new `q4_0_matvec_sdot_inner` (2-row fused) does int8-x (reuses
+  `quantize_act_int8`) → 2 chained `vdotq_s32` per block → one cvt+FMA for the per-block scale:
+  ~10 instr per 32 weights vs ~40 on the old int16→f32 unpack. Wired into `qwen_matvec_q4_0`,
+  `qwen_matvec_q4_0_qkv` and (via the former) `qwen_argmax_matvec_q4_0`; `QWEN_NO_SDOT=1` opts out
+  (same switch as int8). Old float path kept for the fallback, updated to the new packing —
+  full-pipeline **bit-identical** to the old kernel under `QWEN_NO_SDOT=1` (seed-42 wav cmp).
+  Measured on Oracle 4-core Neoverse-N1 (0.6B-base, seed 42, ryan, EN, `--int4 -j4 --stream
+  --stream-chunk 150`, 3 runs): Talker 50.7→**~18.7 ms/f (2.7×)**, CP 139→**~43.2 ms/f (3.2×)**;
+  same-session int8 = 18.2 + 50.9 ms/f → **int4 total ~62 vs int8 ~69 ms/f, RTF ~1.63 vs 1.71** —
+  int4 finally BEATS int8 end-to-end. `--self-test` extended with a q4_0-vs-f32-reference case
+  (SDOT rel_L2 ~4e-3, fallback ~1e-7, argmax exact on all 3 shapes).
+  - Caveats: (a) Talker is now at int8 parity (~18.7 vs 18.2), not 2× faster — at h=1024 the
+    decode+scale work per byte makes q4 compute-bound where int8 SDOT streams; the win is all CP.
+    (b) int8-x on the q4 **lm_heads** (unlike int8, which keeps them f32 per the 2026-06-04
+    refutation) plus per-block rounding forks the greedy trajectory (seed-42 EOS 83→87 frames) —
+    audio sounds equivalent but **quality must be A/B-approved before deploying to the services**.
 
 > ⚠️ **SDOT is ARM-only (`vdotq_s32`).** Its x86 equivalents are now WRITTEN (2026-06-04):
 > the **AVX2 int8/bf16 matvec twins** (`#elif __AVX2__`, validated on the Ryzen box — see 21.3)

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Optional:
   --stream                   Stream audio (decode chunks during generation)
   --stdout                   Output raw s16le PCM to stdout (implies --stream)
   --int8                     INT8 quantized (0.6B & 1.7B; faster, ~same quality) — recommended; uses VNNI on AVX-512 x86, SDOT on ARM
-  --int4                     Q4_0 quantized (experimental; slower than --int8 on CPU)
+  --int4                     Q4_0 quantized (SDOT kernel on ARM: faster than --int8; quality validation pending)
   -j, --threads <n>          Worker threads (default: 4)
   --silent                   Suppress status output
   --debug                    Verbose diagnostics

--- a/main.c
+++ b/main.c
@@ -422,7 +422,7 @@ int main(int argc, char **argv) {
                 fprintf(stderr, "  --delete-voice <path>      Delete a .qvoice file\n");
                 fprintf(stderr, "  --max-ref-duration <secs>  Max ref audio for embedding (default: 30, 0=all)\n");
                 fprintf(stderr, "  --int8                     INT8 quantized Talker + Code Predictor\n");
-                fprintf(stderr, "  --int4                     Q4_0 quantized Talker (1.7B only, smallest memory)\n");
+                fprintf(stderr, "  --int4                     Q4_0 quantized Talker + Code Predictor (SDOT on ARM: faster than --int8)\n");
                 fprintf(stderr, "  -S, --silent               Silent mode\n");
                 fprintf(stderr, "  -D, --debug                Debug mode\n");
                 fprintf(stderr, "  --caps                     Print compiled SIMD/threading capabilities and exit\n");

--- a/qwen_tts.h
+++ b/qwen_tts.h
@@ -349,6 +349,18 @@ typedef struct {
     int frames_decoded;    /* total codec frames processed */
     int samples_produced;  /* total audio samples produced */
     int initialized;       /* 1 after first call */
+
+    /* Exact streaming conv-decoder state (replaces the windowed conv_rf
+     * re-decode): per-conv input tails (pad_left columns, zero-initialized =
+     * causal zero padding on the first chunk) and per-ConvTranspose
+     * overlap-add carries ((kernel-stride) partial output columns).
+     * Allocated lazily on first streaming decode. */
+    float *cs_cn_dw_tail[2];      /* ConvNeXt dwconv tails   [1024 × 6] */
+    float *cs_init_tail;          /* initial conv tail       [1024 × 6] */
+    float *cs_up_carry[4];        /* upsample convT carries  [out_ch × (k-s)] */
+    float *cs_res_tail[4][3];     /* res conv1 tails         [ch × 6·dil] */
+    float *cs_final_tail;         /* final conv tail         [96 × 6] */
+    int cs_alloc;                 /* 1 after tails allocated */
 } qwen_sd_stream_state_t;
 
 /* ========================================================================

--- a/qwen_tts_kernels.c
+++ b/qwen_tts_kernels.c
@@ -1370,10 +1370,13 @@ void qwen_quantize_bf16_to_q4_0(const uint16_t *src_bf16, int rows, int cols,
             dst_row[b].scale = s;
             float inv_s = (s > 0) ? 1.0f / s : 0.0f;
 
-            /* Quantize: round to [-8, 7], store as unsigned [0, 15] */
+            /* Quantize: round to [-8, 7], store as unsigned [0, 15].
+             * DEINTERLEAVED packing: lo nibbles = weights 0-15, hi nibbles =
+             * weights 16-31, so SIMD unpack (and 0x0F / shr 4) yields two
+             * vectors already in natural order — no zip/interleave needed. */
             for (int i = 0; i < 16; i++) {
-                int lo = (int)roundf(vals[2*i] * inv_s);
-                int hi = (int)roundf(vals[2*i+1] * inv_s);
+                int lo = (int)roundf(vals[i] * inv_s);
+                int hi = (int)roundf(vals[i + 16] * inv_s);
                 lo = lo < -8 ? -8 : (lo > 7 ? 7 : lo);
                 hi = hi < -8 ? -8 : (hi > 7 ? 7 : hi);
                 dst_row[b].qs[i] = (uint8_t)((lo + 8) | ((hi + 8) << 4));
@@ -1395,41 +1398,36 @@ static void q4_0_matvec_inner(float *y, const float *x, const q4_0_block_t *W,
             const uint8_t *qs = row[b].qs;
             const float *xb = x + b * Q4_0_BLOCK_SIZE;
 
-            /* Load 16 bytes = 32 nibbles */
+            /* Load 16 bytes = 32 nibbles. DEINTERLEAVED layout:
+             * lo nibbles = weights 0-15, hi nibbles = weights 16-31 (natural order). */
             uint8x16_t raw = vld1q_u8(qs);
             uint8x16_t lo_nibble = vandq_u8(raw, vdupq_n_u8(0x0F));
             uint8x16_t hi_nibble = vshrq_n_u8(raw, 4);
 
-            /* Interleave: [lo0,hi0,lo1,hi1,...] to get 32 values in order */
             /* Convert to signed: subtract 8 */
-            int16x8_t s0 = vreinterpretq_s16_u16(vsubl_u8(vget_low_u8(lo_nibble), vdup_n_u8(8)));
-            int16x8_t s1 = vreinterpretq_s16_u16(vsubl_u8(vget_low_u8(hi_nibble), vdup_n_u8(8)));
-            int16x8_t s2 = vreinterpretq_s16_u16(vsubl_u8(vget_high_u8(lo_nibble), vdup_n_u8(8)));
-            int16x8_t s3 = vreinterpretq_s16_u16(vsubl_u8(vget_high_u8(hi_nibble), vdup_n_u8(8)));
-
-            /* s0 has lo[0..7], s1 has hi[0..7] — need to zip them:
-             * [lo0,hi0,lo1,hi1,lo2,hi2,lo3,hi3] and [lo4,hi4,...,lo7,hi7] */
-            int16x8x2_t z0 = vzipq_s16(s0, s1);  /* z0.val[0]=[lo0,hi0,lo1,hi1,lo2,hi2,lo3,hi3] */
-            int16x8x2_t z1 = vzipq_s16(s2, s3);  /* z1.val[0]=[lo8,hi8,lo9,hi9,...] */
+            int16x8_t s0 = vreinterpretq_s16_u16(vsubl_u8(vget_low_u8(lo_nibble), vdup_n_u8(8)));   /* w0-7 */
+            int16x8_t s1 = vreinterpretq_s16_u16(vsubl_u8(vget_high_u8(lo_nibble), vdup_n_u8(8)));  /* w8-15 */
+            int16x8_t s2 = vreinterpretq_s16_u16(vsubl_u8(vget_low_u8(hi_nibble), vdup_n_u8(8)));   /* w16-23 */
+            int16x8_t s3 = vreinterpretq_s16_u16(vsubl_u8(vget_high_u8(hi_nibble), vdup_n_u8(8)));  /* w24-31 */
 
             /* Convert to f32 and FMA with x — 8 groups of 4 */
             float32x4_t vscale = vdupq_n_f32(scale);
             float32x4_t acc0 = vdupq_n_f32(0), acc1 = vdupq_n_f32(0);
             float32x4_t acc2 = vdupq_n_f32(0), acc3 = vdupq_n_f32(0);
 
-            float32x4_t f0 = vcvtq_f32_s32(vmovl_s16(vget_low_s16(z0.val[0])));
-            float32x4_t f1 = vcvtq_f32_s32(vmovl_s16(vget_high_s16(z0.val[0])));
-            float32x4_t f2 = vcvtq_f32_s32(vmovl_s16(vget_low_s16(z0.val[1])));
-            float32x4_t f3 = vcvtq_f32_s32(vmovl_s16(vget_high_s16(z0.val[1])));
+            float32x4_t f0 = vcvtq_f32_s32(vmovl_s16(vget_low_s16(s0)));
+            float32x4_t f1 = vcvtq_f32_s32(vmovl_s16(vget_high_s16(s0)));
+            float32x4_t f2 = vcvtq_f32_s32(vmovl_s16(vget_low_s16(s1)));
+            float32x4_t f3 = vcvtq_f32_s32(vmovl_s16(vget_high_s16(s1)));
             acc0 = vfmaq_f32(acc0, vmulq_f32(f0, vscale), vld1q_f32(xb));
             acc1 = vfmaq_f32(acc1, vmulq_f32(f1, vscale), vld1q_f32(xb + 4));
             acc2 = vfmaq_f32(acc2, vmulq_f32(f2, vscale), vld1q_f32(xb + 8));
             acc3 = vfmaq_f32(acc3, vmulq_f32(f3, vscale), vld1q_f32(xb + 12));
 
-            float32x4_t f4 = vcvtq_f32_s32(vmovl_s16(vget_low_s16(z1.val[0])));
-            float32x4_t f5 = vcvtq_f32_s32(vmovl_s16(vget_high_s16(z1.val[0])));
-            float32x4_t f6 = vcvtq_f32_s32(vmovl_s16(vget_low_s16(z1.val[1])));
-            float32x4_t f7 = vcvtq_f32_s32(vmovl_s16(vget_high_s16(z1.val[1])));
+            float32x4_t f4 = vcvtq_f32_s32(vmovl_s16(vget_low_s16(s2)));
+            float32x4_t f5 = vcvtq_f32_s32(vmovl_s16(vget_high_s16(s2)));
+            float32x4_t f6 = vcvtq_f32_s32(vmovl_s16(vget_low_s16(s3)));
+            float32x4_t f7 = vcvtq_f32_s32(vmovl_s16(vget_high_s16(s3)));
             acc0 = vfmaq_f32(acc0, vmulq_f32(f4, vscale), vld1q_f32(xb + 16));
             acc1 = vfmaq_f32(acc1, vmulq_f32(f5, vscale), vld1q_f32(xb + 20));
             acc2 = vfmaq_f32(acc2, vmulq_f32(f6, vscale), vld1q_f32(xb + 24));
@@ -1449,9 +1447,9 @@ static void q4_0_matvec_inner(float *y, const float *x, const q4_0_block_t *W,
             __m128i raw = _mm_loadu_si128((const __m128i *)qs);   /* 16 bytes = 32 nibbles */
             __m128i lo = _mm_and_si128(raw, _mm_set1_epi8(0x0F));
             __m128i hi = _mm_and_si128(_mm_srli_epi16(raw, 4), _mm_set1_epi8(0x0F));
-            /* Interleave to value order [lo0,hi0,lo1,hi1,...] and bias by -8 */
-            __m128i il0 = _mm_sub_epi8(_mm_unpacklo_epi8(lo, hi), _mm_set1_epi8(8));
-            __m128i il1 = _mm_sub_epi8(_mm_unpackhi_epi8(lo, hi), _mm_set1_epi8(8));
+            /* DEINTERLEAVED layout: lo = weights 0-15, hi = weights 16-31; bias by -8 */
+            __m128i il0 = _mm_sub_epi8(lo, _mm_set1_epi8(8));
+            __m128i il1 = _mm_sub_epi8(hi, _mm_set1_epi8(8));
             __m256 vs = _mm256_set1_ps(scale);
             __m256 f0 = _mm256_cvtepi32_ps(_mm256_cvtepi8_epi32(il0));
             __m256 f1 = _mm256_cvtepi32_ps(_mm256_cvtepi8_epi32(_mm_srli_si128(il0, 8)));
@@ -1469,16 +1467,88 @@ static void q4_0_matvec_inner(float *y, const float *x, const q4_0_block_t *W,
             const uint8_t *qs = row[b].qs;
             const float *xb = x + b * Q4_0_BLOCK_SIZE;
             for (int i = 0; i < 16; i++) {
-                int lo = (int)(qs[i] & 0x0F) - 8;
-                int hi = (int)(qs[i] >> 4) - 8;
-                sum += scale * (float)lo * xb[2*i];
-                sum += scale * (float)hi * xb[2*i+1];
+                int lo = (int)(qs[i] & 0x0F) - 8;   /* weight i */
+                int hi = (int)(qs[i] >> 4) - 8;     /* weight i+16 */
+                sum += scale * (float)lo * xb[i];
+                sum += scale * (float)hi * xb[i + 16];
             }
         }
 #endif
         y[o] = sum;
     }
 }
+
+#if defined(__ARM_FEATURE_DOTPROD)
+/* Q4_0 matvec via SDOT: y[o] = sx * Σ_b scale[o][b] · Σ_k W[o][b][k]·qx[b][k].
+ * The old path unpacked nibbles to int16→int32→f32 and did f32 FMA (~40 instr
+ * per 32 weights); with the deinterleaved packing this is ~10: vand/vshr/2×vsub
+ * to get two int8x16 in natural order, 2 chained vdotq_s32 against the int8
+ * activations, then one cvt+FMA to apply the per-block scale. 2-row fused to
+ * amortize the qx loads (same pattern as int8_matvec_sdot). Activations are
+ * quantized once per call by the dispatcher (quantize_act_int8). */
+static void q4_0_matvec_sdot_inner(float *y, const int8_t *qx, float sx,
+                                   const q4_0_block_t *W, int cols, int out_dim) {
+    int blocks_per_row = cols / Q4_0_BLOCK_SIZE;
+    const uint8x16_t mlo = vdupq_n_u8(0x0F);
+    const int8x16_t v8 = vdupq_n_s8(8);
+    int o = 0;
+    for (; o + 1 < out_dim; o += 2) {
+        const q4_0_block_t *r0 = W + (size_t)o * blocks_per_row;
+        const q4_0_block_t *r1 = r0 + blocks_per_row;
+        float32x4_t fa = vdupq_n_f32(0), fb = vdupq_n_f32(0);
+        for (int b = 0; b < blocks_per_row; b++) {
+            int8x16_t xlo = vld1q_s8(qx + b * Q4_0_BLOCK_SIZE);
+            int8x16_t xhi = vld1q_s8(qx + b * Q4_0_BLOCK_SIZE + 16);
+
+            uint8x16_t raw0 = vld1q_u8(r0[b].qs);
+            int8x16_t w0lo = vsubq_s8(vreinterpretq_s8_u8(vandq_u8(raw0, mlo)), v8);
+            int8x16_t w0hi = vsubq_s8(vreinterpretq_s8_u8(vshrq_n_u8(raw0, 4)), v8);
+            int32x4_t d0 = vdotq_s32(vdotq_s32(vdupq_n_s32(0), w0lo, xlo), w0hi, xhi);
+            fa = vfmaq_n_f32(fa, vcvtq_f32_s32(d0), r0[b].scale);
+
+            uint8x16_t raw1 = vld1q_u8(r1[b].qs);
+            int8x16_t w1lo = vsubq_s8(vreinterpretq_s8_u8(vandq_u8(raw1, mlo)), v8);
+            int8x16_t w1hi = vsubq_s8(vreinterpretq_s8_u8(vshrq_n_u8(raw1, 4)), v8);
+            int32x4_t d1 = vdotq_s32(vdotq_s32(vdupq_n_s32(0), w1lo, xlo), w1hi, xhi);
+            fb = vfmaq_n_f32(fb, vcvtq_f32_s32(d1), r1[b].scale);
+        }
+        y[o]     = vaddvq_f32(fa) * sx;
+        y[o + 1] = vaddvq_f32(fb) * sx;
+    }
+    if (o < out_dim) {
+        const q4_0_block_t *r0 = W + (size_t)o * blocks_per_row;
+        float32x4_t fa = vdupq_n_f32(0);
+        for (int b = 0; b < blocks_per_row; b++) {
+            uint8x16_t raw0 = vld1q_u8(r0[b].qs);
+            int8x16_t w0lo = vsubq_s8(vreinterpretq_s8_u8(vandq_u8(raw0, mlo)), v8);
+            int8x16_t w0hi = vsubq_s8(vreinterpretq_s8_u8(vshrq_n_u8(raw0, 4)), v8);
+            int32x4_t d0 = vdotq_s32(vdupq_n_s32(0), w0lo, vld1q_s8(qx + b * Q4_0_BLOCK_SIZE));
+            d0 = vdotq_s32(d0, w0hi, vld1q_s8(qx + b * Q4_0_BLOCK_SIZE + 16));
+            fa = vfmaq_n_f32(fa, vcvtq_f32_s32(d0), r0[b].scale);
+        }
+        y[o] = vaddvq_f32(fa) * sx;
+    }
+}
+
+typedef struct {
+    float *y; const int8_t *qx; float sx; const q4_0_block_t *W; int rows, cols, blocks_per_row;
+} q4_0_sdot_ctx;
+static void q4_0_sdot_task(size_t tid, size_t nt, void *vc) {
+    q4_0_sdot_ctx *c = (q4_0_sdot_ctx *)vc;
+    int r0 = (int)(tid * (size_t)c->rows / nt);
+    int r1 = (int)((tid + 1) * (size_t)c->rows / nt);
+    q4_0_matvec_sdot_inner(c->y + r0, c->qx, c->sx,
+                           c->W + (size_t)r0 * c->blocks_per_row, c->cols, r1 - r0);
+}
+
+/* Shared QWEN_NO_SDOT check (same env var as the int8 path — one switch
+ * disables all native int8-dot kernels for A/B benchmarking). */
+static int q4_sdot_disabled(void) {
+    static int off = -1;
+    if (off < 0) { const char *e = getenv("QWEN_NO_SDOT"); off = (e && e[0] == '1'); }
+    return off;
+}
+#endif /* __ARM_FEATURE_DOTPROD */
 
 typedef struct {
     float *y; const q4_0_block_t *W; const float *x; int rows, cols, blocks_per_row;
@@ -1493,6 +1563,22 @@ static void q4_0_mv_task(size_t tid, size_t nt, void *vc) {
 void qwen_matvec_q4_0(float *y, const q4_0_block_t *W, const float *x,
                        int rows, int cols) {
     int nt = g_n_threads;
+#if defined(__ARM_FEATURE_DOTPROD)
+    /* SDOT path: quantize the shared activation x once, then int8×int8 dot
+     * against the unpacked nibbles (same shape as the int8 SDOT dispatch). */
+    enum { QX_MAX = 8192 };
+    if (!q4_sdot_disabled() && cols <= QX_MAX) {
+        int8_t qx_buf[QX_MAX];
+        float sx = quantize_act_int8(qx_buf, x, cols);
+        if (nt > 1 && rows >= 256) {
+            q4_0_sdot_ctx c = { y, qx_buf, sx, W, rows, cols, cols / Q4_0_BLOCK_SIZE };
+            qwen_parallel((size_t)nt, q4_0_sdot_task, &c);
+            return;
+        }
+        q4_0_matvec_sdot_inner(y, qx_buf, sx, W, cols, rows);
+        return;
+    }
+#endif
     if (nt > 1 && rows >= 256) {
         q4_0_mv_ctx c = { y, W, x, rows, cols, cols / Q4_0_BLOCK_SIZE };
         qwen_parallel((size_t)nt, q4_0_mv_task, &c);
@@ -1537,11 +1623,67 @@ static void q4_0_qkv_task(size_t tid, size_t nt, void *vc) {
         }
     }
 }
+#if defined(__ARM_FEATURE_DOTPROD)
+/* SDOT twin of q4_0_qkv_task: same [Q|K|V] row-space partition, int8 activations. */
+typedef struct {
+    float *q, *k, *v;
+    const q4_0_block_t *Wq, *Wk, *Wv;
+    const int8_t *qx; float sx;
+    int in_dim, q_dim, kv_dim, blocks_per_row;
+} q4_0_qkv_sdot_ctx;
+static void q4_0_qkv_sdot_task(size_t tid, size_t nt, void *vc) {
+    q4_0_qkv_sdot_ctx *c = (q4_0_qkv_sdot_ctx *)vc;
+    int total = c->q_dim + 2 * c->kv_dim;
+    int r0 = (int)(tid * (size_t)total / nt);
+    int r1 = (int)((tid + 1) * (size_t)total / nt);
+    for (int r = r0; r < r1; ) {
+        if (r < c->q_dim) {
+            int end = r1 < c->q_dim ? r1 : c->q_dim;
+            q4_0_matvec_sdot_inner(c->q + r, c->qx, c->sx,
+                                   c->Wq + (size_t)r * c->blocks_per_row,
+                                   c->in_dim, end - r);
+            r = end;
+        } else if (r < c->q_dim + c->kv_dim) {
+            int local = r - c->q_dim;
+            int end = r1 < c->q_dim + c->kv_dim ? r1 : c->q_dim + c->kv_dim;
+            int local_end = end - c->q_dim;
+            q4_0_matvec_sdot_inner(c->k + local, c->qx, c->sx,
+                                   c->Wk + (size_t)local * c->blocks_per_row,
+                                   c->in_dim, local_end - local);
+            r = end;
+        } else {
+            int local = r - c->q_dim - c->kv_dim;
+            int local_end = r1 - c->q_dim - c->kv_dim;
+            q4_0_matvec_sdot_inner(c->v + local, c->qx, c->sx,
+                                   c->Wv + (size_t)local * c->blocks_per_row,
+                                   c->in_dim, local_end - local);
+            r = r1;
+        }
+    }
+}
+#endif /* __ARM_FEATURE_DOTPROD */
 void qwen_matvec_q4_0_qkv(float *q, float *k, float *v,
                             const q4_0_block_t *Wq, const q4_0_block_t *Wk,
                             const q4_0_block_t *Wv,
                             const float *x, int in_dim, int q_dim, int kv_dim) {
     int nt = g_n_threads;
+#if defined(__ARM_FEATURE_DOTPROD)
+    enum { QX_MAX = 8192 };
+    if (!q4_sdot_disabled() && in_dim <= QX_MAX) {
+        int8_t qx_buf[QX_MAX];
+        float sx = quantize_act_int8(qx_buf, x, in_dim);
+        if (nt > 1) {
+            q4_0_qkv_sdot_ctx c = { q, k, v, Wq, Wk, Wv, qx_buf, sx,
+                                    in_dim, q_dim, kv_dim, in_dim / Q4_0_BLOCK_SIZE };
+            qwen_parallel((size_t)nt, q4_0_qkv_sdot_task, &c);
+            return;
+        }
+        q4_0_matvec_sdot_inner(q, qx_buf, sx, Wq, in_dim, q_dim);
+        q4_0_matvec_sdot_inner(k, qx_buf, sx, Wk, in_dim, kv_dim);
+        q4_0_matvec_sdot_inner(v, qx_buf, sx, Wv, in_dim, kv_dim);
+        return;
+    }
+#endif
     if (nt > 1) {
         q4_0_qkv_ctx c = { q, k, v, Wq, Wk, Wv, x, in_dim, q_dim, kv_dim,
                            in_dim / Q4_0_BLOCK_SIZE };
@@ -2346,8 +2488,9 @@ int qwen_argmax_matvec_bf16(const float *x, const uint16_t *W_bf16, int in_dim, 
  * Cross-ISA correctness proof for the matvec kernels that does NOT depend on a
  * full-pipeline golden — immune to the greedy-decode trajectory fork that makes
  * cross-ISA / cross-precision audio mel-corr drop benignly. Runs each dispatched
- * matvec (bf16 / int8 / argmax-int8) against an independent f32 reference on
- * deterministic pseudo-random data and checks the error is within tolerance.
+ * matvec (bf16 / int8 / argmax-int8 / q4_0 / argmax-q4_0) against an independent
+ * f32 reference on deterministic pseudo-random data and checks the error is
+ * within tolerance.
  *
  * On x86 with SIMD=avx512vnni this exercises the VNNI int8 dot (`_mm512_dpbusd`)
  * and the __m512 bf16 matvec (the two UNVALIDATED AVX-512 paths). On ARM it
@@ -2442,13 +2585,61 @@ int qwen_kernel_selftest(void *out) {
                         (amax_got >= 0 && amax_got < rows &&
                          (amax_val - ref[amax_got]) < 0.02 * (fabs(amax_val) + 1e-3));
 
+        /* ---- q4_0 matvec ---- (reference = f32 dot with exactly-dequantized q4
+         * weights, decoded per the DEINTERLEAVED layout: lo nibbles = weights
+         * 0-15, hi = 16-31 — validates pack+unpack consistency AND the SDOT
+         * kernel in one shot; activation quant makes the same near-zero-per-row
+         * noise as int8, so use the same global L2 metric). */
+        int nblk = cols / Q4_0_BLOCK_SIZE;
+        q4_0_block_t *wq4 = malloc((size_t)rows * nblk * sizeof(q4_0_block_t));
+        double rel_l2_q4 = 1.0;
+        int q4_argmax_ok = 0, q4amax_ref = 0, q4amax_got = -1;
+        if (wq4) {
+            qwen_quantize_bf16_to_q4_0(wb, rows, cols, wq4);
+            for (int r = 0; r < rows; r++) {
+                const q4_0_block_t *row = wq4 + (size_t)r * nblk;
+                float s = 0.0f;
+                for (int b = 0; b < nblk; b++) {
+                    const float *xb = x + b * Q4_0_BLOCK_SIZE;
+                    float bs = 0.0f;
+                    for (int i = 0; i < 16; i++) {
+                        bs += (float)((int)(row[b].qs[i] & 0x0F) - 8) * xb[i];
+                        bs += (float)((int)(row[b].qs[i] >> 4)   - 8) * xb[i + 16];
+                    }
+                    s += row[b].scale * bs;
+                }
+                ref[r] = s;
+            }
+            qwen_matvec_q4_0(y, wq4, x, rows, cols);
+            l2_num = 0.0; l2_den = 0.0;
+            for (int r = 0; r < rows; r++) {
+                double d = (double)y[r] - ref[r];
+                l2_num += d * d;
+                l2_den += (double)ref[r] * ref[r];
+            }
+            rel_l2_q4 = sqrt(l2_num / (l2_den + 1e-12));
+
+            float q4amax_val = ref[0];
+            for (int r = 1; r < rows; r++)
+                if (ref[r] > q4amax_val) { q4amax_val = ref[r]; q4amax_ref = r; }
+            q4amax_got = qwen_argmax_matvec_q4_0(x, wq4, cols, rows);
+            q4_argmax_ok = (q4amax_got == q4amax_ref) ||
+                           (q4amax_got >= 0 && q4amax_got < rows &&
+                            (q4amax_val - ref[q4amax_got]) < 0.02 * (fabs(q4amax_val) + 1e-3));
+            free(wq4);
+        }
+
         int bf16_ok = max_rel_bf16 < 1e-2;   /* bf16: only fp accumulation-order drift */
         int i8_ok   = rel_l2_i8    < 3e-2;   /* int8: activation-quant noise (~0.7% expected) */
-        if (!bf16_ok || !i8_ok || !argmax_ok) failures++;
-        fprintf(f, "  [%4dx%-4d] bf16 max_rel=%.2e %s | int8 rel_L2=%.2e %s | argmax %s (ref=%d got=%d)\n",
+        int q4_ok   = rel_l2_q4    < 3e-2;   /* q4_0: same activation-quant noise on SDOT */
+        if (!bf16_ok || !i8_ok || !argmax_ok || !q4_ok || !q4_argmax_ok) failures++;
+        fprintf(f, "  [%4dx%-4d] bf16 max_rel=%.2e %s | int8 rel_L2=%.2e %s | argmax %s (ref=%d got=%d)\n"
+                   "             q4_0 rel_L2=%.2e %s | q4 argmax %s (ref=%d got=%d)\n",
                 rows, cols, max_rel_bf16, bf16_ok ? "OK" : "FAIL",
                 rel_l2_i8, i8_ok ? "OK" : "FAIL",
-                argmax_ok ? "OK" : "FAIL", amax_ref, amax_got);
+                argmax_ok ? "OK" : "FAIL", amax_ref, amax_got,
+                rel_l2_q4, q4_ok ? "OK" : "FAIL",
+                q4_argmax_ok ? "OK" : "FAIL", q4amax_ref, q4amax_got);
 
         free(x); free(wf); free(wb); free(wi); free(sc); free(ref); free(y);
     }

--- a/qwen_tts_kernels.c
+++ b/qwen_tts_kernels.c
@@ -18,6 +18,10 @@
 #ifdef __AVX2__
 #include <immintrin.h>
 #endif
+#if !defined(_WIN32)
+#include <pthread.h>
+#endif
+#include <stdatomic.h>
 
 #ifdef USE_BLAS
 #ifdef __APPLE__
@@ -2249,9 +2253,9 @@ void qwen_bf16_to_f32_vec(float *dst, const uint16_t *src_bf16, int n) {
  * Snake activation: x += (1/exp(beta)) * sin²(exp(alpha) * x)
  * ======================================================================== */
 
-void qwen_snake_activation(float *data, int channels, int length,
-                            const float *log_alpha, const float *log_beta) {
-    for (int c = 0; c < channels; c++) {
+static void snake_rows(float *data, int c0, int c1, int length,
+                       const float *log_alpha, const float *log_beta) {
+    for (int c = c0; c < c1; c++) {
         float a = expf(log_alpha[c]);
         float inv_b = expf(-log_beta[c]);
         float *row = data + (int64_t)c * length;
@@ -2278,18 +2282,32 @@ void qwen_snake_activation(float *data, int channels, int length,
         }
 #elif defined(__ARM_NEON)
         {
-            float32x4_t va = vdupq_n_f32(a);
-            float32x4_t vinv_b = vdupq_n_f32(inv_b);
+            /* Vectorized sin² via period-π reduction: sin²(y) = sin²(y − nπ),
+             * n = round(y/π), so u ∈ [−π/2, π/2] and an odd sin polynomial
+             * suffices — squaring makes the sign of sin(y−nπ) irrelevant. */
+            const float32x4_t va = vdupq_n_f32(a);
+            const float32x4_t vinv_b = vdupq_n_f32(inv_b);
+            const float32x4_t inv_pi = vdupq_n_f32(0.31830988618379067f);
+            const float32x4_t pi_hi = vdupq_n_f32(3.14159274101257324f);
+            const float32x4_t pi_lo = vdupq_n_f32(-8.74227765734758577e-8f);
+            const float32x4_t c3  = vdupq_n_f32(-1.6666666666e-1f);
+            const float32x4_t c5  = vdupq_n_f32( 8.3333333333e-3f);
+            const float32x4_t c7  = vdupq_n_f32(-1.9841269841e-4f);
+            const float32x4_t c9  = vdupq_n_f32( 2.7557319224e-6f);
+            const float32x4_t c11 = vdupq_n_f32(-2.5052108385e-8f);
             int t = 0;
             for (; t + 3 < length; t += 4) {
                 float32x4_t x = vld1q_f32(row + t);
-                float32x4_t ax = vmulq_f32(va, x);
-                /* Scalar sinf for each lane (no NEON intrinsic for sin) */
-                float ax_s[4];
-                vst1q_f32(ax_s, ax);
-                float s_arr[4] = { sinf(ax_s[0]), sinf(ax_s[1]),
-                                   sinf(ax_s[2]), sinf(ax_s[3]) };
-                float32x4_t s = vld1q_f32(s_arr);
+                float32x4_t y = vmulq_f32(va, x);
+                float32x4_t n = vrndaq_f32(vmulq_f32(y, inv_pi));
+                float32x4_t u = vfmsq_f32(y, n, pi_hi);
+                u = vfmsq_f32(u, n, pi_lo);
+                float32x4_t u2 = vmulq_f32(u, u);
+                float32x4_t p = vfmaq_f32(c9, c11, u2);
+                p = vfmaq_f32(c7, p, u2);
+                p = vfmaq_f32(c5, p, u2);
+                p = vfmaq_f32(c3, p, u2);
+                float32x4_t s = vfmaq_f32(u, vmulq_f32(u, u2), p);
                 float32x4_t s2 = vmulq_f32(s, s);
                 x = vfmaq_f32(x, vinv_b, s2);
                 vst1q_f32(row + t, x);
@@ -2328,6 +2346,46 @@ void qwen_snake_activation(float *data, int channels, int length,
         }
 #endif
     }
+}
+
+#if defined(__ARM_FEATURE_DOTPROD) && !defined(_WIN32)
+/* Decoder-side worker pool, defined with the int8 conv engine below.
+ * Used here to spread snake over cores (it runs on the decoder thread,
+ * which may not touch the main qwen_parallel pool). */
+static void sd_pool_run(void (*fn)(void *), void *ctx);
+
+typedef struct {
+    float *data;
+    int channels, length;
+    const float *log_alpha, *log_beta;
+    _Atomic int next;
+    int chunk;
+} snake_job_t;
+
+static void snake_worker(void *vj) {
+    snake_job_t *j = (snake_job_t *)vj;
+    for (;;) {
+        int c0 = atomic_fetch_add(&j->next, j->chunk);
+        if (c0 >= j->channels) break;
+        int c1 = c0 + j->chunk < j->channels ? c0 + j->chunk : j->channels;
+        snake_rows(j->data, c0, c1, j->length, j->log_alpha, j->log_beta);
+    }
+}
+#endif
+
+void qwen_snake_activation(float *data, int channels, int length,
+                            const float *log_alpha, const float *log_beta) {
+#if defined(__ARM_FEATURE_DOTPROD) && !defined(_WIN32)
+    if ((int64_t)channels * length >= 65536 && qwen_get_threads() > 1) {
+        int chunk = channels / (qwen_get_threads() * 4);
+        if (chunk < 1) chunk = 1;
+        snake_job_t job = { data, channels, length, log_alpha, log_beta, 0, chunk };
+        atomic_store(&job.next, 0);
+        sd_pool_run(snake_worker, &job);
+        return;
+    }
+#endif
+    snake_rows(data, 0, channels, length, log_alpha, log_beta);
 }
 
 /* ========================================================================
@@ -2648,3 +2706,419 @@ int qwen_kernel_selftest(void *out) {
             failures, failures == 1 ? "" : "s");
     return failures;
 }
+
+/* ========================================================================
+ * INT8 SDOT conv engine for the speech decoder (QWEN_SD_INT8=1)
+ *
+ * The decoder's conv stack (res blocks + upsample transposes + initial conv)
+ * is ~75% of decode wall time as fp32 sgemm. This path quantizes BOTH
+ * operands int8 with per-BLK-element scales (Q8_0-style; one absmax per
+ * whole im2col column is not enough — large channels crush small ones,
+ * ~17dB SNR; per-128 blocks align with channel groups and restore ~40dB+)
+ * and runs the im2col GEMM with vdotq_s32: 4x the MAC throughput of fp32
+ * FMA on Neoverse-N1, ~1.4x effective after block-scale epilogues.
+ *
+ * Layout: weights [M, Kp] quantized once (cached by caller); activations are
+ * a TRANSPOSED im2col [N, Kp] built per 128-column panel. Kp is K padded to
+ * a BLK multiple, zero-filled (zero blocks contribute 0 regardless of scale).
+ * Scales are [row][Kp/BLK]. The dot loop is a 2x4 register tile: int32
+ * accumulators per BLK, folded into fp32 accumulators with the combined
+ * weight-block x activation-block scale.
+ *
+ * Threading: work chunks are claimed atomically by a small dedicated pool —
+ * the main qwen_parallel pool is NOT reentrant and is owned by the
+ * generation thread; the decoder runs concurrently on its own thread.
+ * ======================================================================== */
+
+int qwen_sd_int8_available(void) {
+#if defined(__ARM_FEATURE_DOTPROD)
+    return 1;
+#else
+    return 0;
+#endif
+}
+
+int qwen_int8_kp(int K, int blk) { return (K + blk - 1) / blk * blk; }
+
+/* Per-row, per-BLK-block absmax int8 quantization. dst rows are Kp-strided
+ * and zero-padded; scales is [rows][Kp/blk]. blk must be a multiple of 16. */
+void qwen_int8_quant_rows(int8_t *dst, float *scales, const float *src,
+                          int rows, int K, int Kp, int blk) {
+    int nblk = Kp / blk;
+    for (int r = 0; r < rows; r++) {
+        const float *s = src + (int64_t)r * K;
+        int8_t *d = dst + (int64_t)r * Kp;
+        float *sc = scales + (int64_t)r * nblk;
+        for (int b = 0; b < nblk; b++) {
+            int k0 = b * blk;
+            int kn = K - k0 < blk ? K - k0 : blk;  /* valid elems in block */
+            if (kn <= 0) { sc[b] = 1.0f; memset(d + k0, 0, blk); continue; }
+            float amax = 0.0f;
+            int i = 0;
+#ifdef __ARM_NEON
+            float32x4_t vmax = vdupq_n_f32(0.0f);
+            for (; i + 3 < kn; i += 4)
+                vmax = vmaxq_f32(vmax, vabsq_f32(vld1q_f32(s + k0 + i)));
+            amax = vmaxvq_f32(vmax);
+#endif
+            for (; i < kn; i++) { float a = fabsf(s[k0 + i]); if (a > amax) amax = a; }
+            float scale = amax > 0.0f ? amax / 127.0f : 1.0f;
+            float inv = amax > 0.0f ? 127.0f / amax : 0.0f;
+            sc[b] = scale;
+            i = 0;
+#ifdef __ARM_NEON
+            float32x4_t vinv = vdupq_n_f32(inv);
+            for (; i + 15 < kn; i += 16) {
+                int32x4_t q0 = vcvtnq_s32_f32(vmulq_f32(vld1q_f32(s + k0 + i),      vinv));
+                int32x4_t q1 = vcvtnq_s32_f32(vmulq_f32(vld1q_f32(s + k0 + i + 4),  vinv));
+                int32x4_t q2 = vcvtnq_s32_f32(vmulq_f32(vld1q_f32(s + k0 + i + 8),  vinv));
+                int32x4_t q3 = vcvtnq_s32_f32(vmulq_f32(vld1q_f32(s + k0 + i + 12), vinv));
+                int16x8_t p0 = vcombine_s16(vqmovn_s32(q0), vqmovn_s32(q1));
+                int16x8_t p1 = vcombine_s16(vqmovn_s32(q2), vqmovn_s32(q3));
+                vst1q_s8(d + k0 + i, vcombine_s8(vqmovn_s16(p0), vqmovn_s16(p1)));
+            }
+#endif
+            for (; i < kn; i++) {
+                float q = s[k0 + i] * inv;
+                int v = (int)(q >= 0 ? q + 0.5f : q - 0.5f);
+                if (v > 127) v = 127;
+                if (v < -127) v = -127;
+                d[k0 + i] = (int8_t)v;
+            }
+            for (; i < blk; i++) d[k0 + i] = 0;
+        }
+    }
+}
+
+#if defined(__ARM_FEATURE_DOTPROD)
+
+/* 2 rows x 4 cols register tile with per-block fp32 accumulation.
+ * 8 int32 dot accs + 8 fp32 accs + 6 live loads = 22 registers. */
+static inline void sd_tile_2x4(float *out, int out_ld, int m, int tcol,
+                               const int8_t *Wq, const float *swb, const float *bias,
+                               const int8_t *Xq, const float *sab, int xrow,
+                               int Kp, int blk, int nblk) {
+    const int8_t *w0 = Wq + (size_t)(m + 0) * Kp, *w1 = Wq + (size_t)(m + 1) * Kp;
+    const int8_t *x0 = Xq + (size_t)(xrow + 0) * Kp, *x1 = Xq + (size_t)(xrow + 1) * Kp;
+    const int8_t *x2 = Xq + (size_t)(xrow + 2) * Kp, *x3 = Xq + (size_t)(xrow + 3) * Kp;
+    const float *sw0 = swb + (size_t)(m + 0) * nblk, *sw1 = swb + (size_t)(m + 1) * nblk;
+    const float *sa0 = sab + (size_t)(xrow + 0) * nblk, *sa1 = sab + (size_t)(xrow + 1) * nblk;
+    const float *sa2 = sab + (size_t)(xrow + 2) * nblk, *sa3 = sab + (size_t)(xrow + 3) * nblk;
+    float32x4_t f00 = vdupq_n_f32(0), f01 = f00, f02 = f00, f03 = f00;
+    float32x4_t f10 = f00, f11 = f00, f12 = f00, f13 = f00;
+    for (int b = 0; b < nblk; b++) {
+        int32x4_t a00 = vdupq_n_s32(0), a01 = a00, a02 = a00, a03 = a00;
+        int32x4_t a10 = a00, a11 = a00, a12 = a00, a13 = a00;
+        int kend = (b + 1) * blk;
+        for (int k = b * blk; k < kend; k += 16) {
+            int8x16_t xv0 = vld1q_s8(x0 + k), xv1 = vld1q_s8(x1 + k);
+            int8x16_t xv2 = vld1q_s8(x2 + k), xv3 = vld1q_s8(x3 + k);
+            int8x16_t wv = vld1q_s8(w0 + k);
+            a00 = vdotq_s32(a00, wv, xv0); a01 = vdotq_s32(a01, wv, xv1);
+            a02 = vdotq_s32(a02, wv, xv2); a03 = vdotq_s32(a03, wv, xv3);
+            wv = vld1q_s8(w1 + k);
+            a10 = vdotq_s32(a10, wv, xv0); a11 = vdotq_s32(a11, wv, xv1);
+            a12 = vdotq_s32(a12, wv, xv2); a13 = vdotq_s32(a13, wv, xv3);
+        }
+        float s0 = sw0[b], s1 = sw1[b];
+        f00 = vfmaq_n_f32(f00, vcvtq_f32_s32(a00), s0 * sa0[b]);
+        f01 = vfmaq_n_f32(f01, vcvtq_f32_s32(a01), s0 * sa1[b]);
+        f02 = vfmaq_n_f32(f02, vcvtq_f32_s32(a02), s0 * sa2[b]);
+        f03 = vfmaq_n_f32(f03, vcvtq_f32_s32(a03), s0 * sa3[b]);
+        f10 = vfmaq_n_f32(f10, vcvtq_f32_s32(a10), s1 * sa0[b]);
+        f11 = vfmaq_n_f32(f11, vcvtq_f32_s32(a11), s1 * sa1[b]);
+        f12 = vfmaq_n_f32(f12, vcvtq_f32_s32(a12), s1 * sa2[b]);
+        f13 = vfmaq_n_f32(f13, vcvtq_f32_s32(a13), s1 * sa3[b]);
+    }
+    float b0 = bias ? bias[m + 0] : 0.0f, b1 = bias ? bias[m + 1] : 0.0f;
+    float *o0 = out + (size_t)(m + 0) * out_ld + tcol;
+    float *o1 = out + (size_t)(m + 1) * out_ld + tcol;
+    o0[0] = vaddvq_f32(f00) + b0; o0[1] = vaddvq_f32(f01) + b0;
+    o0[2] = vaddvq_f32(f02) + b0; o0[3] = vaddvq_f32(f03) + b0;
+    o1[0] = vaddvq_f32(f10) + b1; o1[1] = vaddvq_f32(f11) + b1;
+    o1[2] = vaddvq_f32(f12) + b1; o1[3] = vaddvq_f32(f13) + b1;
+}
+
+/* 1 row x up to 4 cols tail tile */
+static inline void sd_tile_1xN(float *out, int out_ld, int m, int tcol,
+                               const int8_t *Wq, const float *swb, const float *bias,
+                               const int8_t *Xq, const float *sab, int xrow, int ncols,
+                               int Kp, int blk, int nblk) {
+    const int8_t *w0 = Wq + (size_t)m * Kp;
+    const float *sw0 = swb + (size_t)m * nblk;
+    float32x4_t fc[4] = { vdupq_n_f32(0), vdupq_n_f32(0), vdupq_n_f32(0), vdupq_n_f32(0) };
+    for (int b = 0; b < nblk; b++) {
+        int32x4_t ac[4] = { vdupq_n_s32(0), vdupq_n_s32(0), vdupq_n_s32(0), vdupq_n_s32(0) };
+        int kend = (b + 1) * blk;
+        for (int k = b * blk; k < kend; k += 16) {
+            int8x16_t wv = vld1q_s8(w0 + k);
+            for (int c = 0; c < ncols; c++)
+                ac[c] = vdotq_s32(ac[c], wv, vld1q_s8(Xq + (size_t)(xrow + c) * Kp + k));
+        }
+        float s0 = sw0[b];
+        for (int c = 0; c < ncols; c++)
+            fc[c] = vfmaq_n_f32(fc[c], vcvtq_f32_s32(ac[c]),
+                                s0 * sab[(size_t)(xrow + c) * nblk + b]);
+    }
+    float bb = bias ? bias[m] : 0.0f;
+    for (int c = 0; c < ncols; c++)
+        out[(size_t)m * out_ld + tcol + c] = vaddvq_f32(fc[c]) + bb;
+}
+
+/* GEMM over one activation panel: out[m, tcol0 + c] for c in [0, nc).
+ * Row-blocked (32) so the 4-column activation quad stays cache-resident
+ * across row pairs. */
+static void sd_gemm_panel(float *out, int out_ld, int M,
+                          const int8_t *Wq, const float *swb, const float *bias,
+                          const int8_t *Xq, const float *sab,
+                          int tcol0, int nc, int Kp, int blk) {
+    int nblk = Kp / blk;
+    for (int rb = 0; rb < M; rb += 32) {
+        int rbe = rb + 32 < M ? rb + 32 : M;
+        int c = 0;
+        for (; c + 3 < nc; c += 4) {
+            int m = rb;
+            for (; m + 1 < rbe; m += 2)
+                sd_tile_2x4(out, out_ld, m, tcol0 + c, Wq, swb, bias, Xq, sab, c, Kp, blk, nblk);
+            for (; m < rbe; m++)
+                sd_tile_1xN(out, out_ld, m, tcol0 + c, Wq, swb, bias, Xq, sab, c, 4, Kp, blk, nblk);
+        }
+        if (c < nc)
+            for (int m = rb; m < rbe; m++)
+                sd_tile_1xN(out, out_ld, m, tcol0 + c, Wq, swb, bias, Xq, sab, c, nc - c, Kp, blk, nblk);
+    }
+}
+
+/* ---------------- dedicated worker pool (decoder thread side) ---------- */
+
+#define SD_POOL_MAX_WORKERS 8
+
+static pthread_mutex_t sdp_mu = PTHREAD_MUTEX_INITIALIZER;
+static pthread_cond_t  sdp_cv = PTHREAD_COND_INITIALIZER;
+static pthread_cond_t  sdp_done_cv = PTHREAD_COND_INITIALIZER;
+static pthread_t sdp_threads[SD_POOL_MAX_WORKERS];
+static int sdp_nworkers = 0;         /* spawned workers (excludes caller) */
+static int sdp_started = 0;
+static unsigned sdp_gen = 0;
+static int sdp_pending = 0;          /* workers still running current job */
+static void (*sdp_fn)(void *) = NULL;
+static void *sdp_ctx = NULL;
+
+static void *sdp_worker_main(void *arg) {
+    (void)arg;
+    qwen_ftz_on();
+    unsigned seen = 0;
+    for (;;) {
+        pthread_mutex_lock(&sdp_mu);
+        while (sdp_gen == seen)
+            pthread_cond_wait(&sdp_cv, &sdp_mu);
+        seen = sdp_gen;
+        void (*fn)(void *) = sdp_fn;
+        void *ctx = sdp_ctx;
+        pthread_mutex_unlock(&sdp_mu);
+        fn(ctx);
+        pthread_mutex_lock(&sdp_mu);
+        if (--sdp_pending == 0)
+            pthread_cond_signal(&sdp_done_cv);
+        pthread_mutex_unlock(&sdp_mu);
+    }
+    return NULL;
+}
+
+/* Run fn(ctx) on caller + workers; fn must claim work via an atomic counter
+ * in ctx. One job at a time (decoder is single-threaded per synthesis). */
+static void sd_pool_run(void (*fn)(void *), void *ctx) {
+    /* Worker count (excluding the calling decoder thread). Default matches
+     * the engine thread count; QWEN_SD_THREADS overrides (total threads). */
+    static int cfg = -1;
+    if (cfg < 0) {
+        const char *e = getenv("QWEN_SD_THREADS");
+        cfg = e ? atoi(e) : 0;
+    }
+    int want = (cfg > 0 ? cfg : qwen_get_threads()) - 1;
+    if (want > SD_POOL_MAX_WORKERS) want = SD_POOL_MAX_WORKERS;
+    if (want < 0) want = 0;
+    pthread_mutex_lock(&sdp_mu);
+    if (!sdp_started) {
+        for (int i = 0; i < want; i++)
+            if (pthread_create(&sdp_threads[sdp_nworkers], NULL, sdp_worker_main, NULL) == 0)
+                sdp_nworkers++;
+        sdp_started = 1;
+    }
+    sdp_fn = fn;
+    sdp_ctx = ctx;
+    sdp_pending = sdp_nworkers;
+    sdp_gen++;
+    pthread_cond_broadcast(&sdp_cv);
+    pthread_mutex_unlock(&sdp_mu);
+
+    fn(ctx);  /* caller participates */
+
+    pthread_mutex_lock(&sdp_mu);
+    while (sdp_pending > 0)
+        pthread_cond_wait(&sdp_done_cv, &sdp_mu);
+    pthread_mutex_unlock(&sdp_mu);
+}
+
+/* ---------------- threaded int8 conv1d (im2col per panel) -------------- */
+
+#define SD_INT8_NC 128  /* activation columns per panel */
+
+typedef struct {
+    float *out;
+    const float *in;
+    const int8_t *Wq; const float *sw; const float *bias;
+    int in_ch, out_ch, length, kernel, dilation, Kp, blk;
+    _Atomic int next_panel;
+    int n_panels;
+} sd_conv_job_t;
+
+static void sd_conv1d_worker(void *vj) {
+    sd_conv_job_t *j = (sd_conv_job_t *)vj;
+    int K = j->in_ch * j->kernel;
+    int nblk = j->Kp / j->blk;
+    int pad_left = (j->kernel - 1) * j->dilation;
+    float *colf = (float *)aligned_malloc((size_t)SD_INT8_NC * K * sizeof(float));
+    int8_t *colq = (int8_t *)aligned_malloc((size_t)SD_INT8_NC * j->Kp);
+    float *sa = (float *)aligned_malloc((size_t)SD_INT8_NC * nblk * sizeof(float));
+    for (;;) {
+        int p = atomic_fetch_add(&j->next_panel, 1);
+        if (p >= j->n_panels) break;
+        int t0 = p * SD_INT8_NC;
+        int nc = j->length - t0 < SD_INT8_NC ? j->length - t0 : SD_INT8_NC;
+        /* transposed im2col: colf[c][ic*kernel+kk] = in[ic][t0+c-pad+kk*dil] */
+        for (int c = 0; c < nc; c++) {
+            float *dst = colf + (size_t)c * K;
+            int tt = t0 + c - pad_left;
+            for (int ic = 0; ic < j->in_ch; ic++) {
+                const float *src = j->in + (size_t)ic * j->length;
+                float *dk = dst + (size_t)ic * j->kernel;
+                for (int kk = 0; kk < j->kernel; kk++) {
+                    int pos = tt + kk * j->dilation;
+                    dk[kk] = (pos >= 0 && pos < j->length) ? src[pos] : 0.0f;
+                }
+            }
+        }
+        qwen_int8_quant_rows(colq, sa, colf, nc, K, j->Kp, j->blk);
+        sd_gemm_panel(j->out, j->length, j->out_ch, j->Wq, j->sw, j->bias,
+                      colq, sa, t0, nc, j->Kp, j->blk);
+    }
+    free(colf); free(colq); free(sa);
+}
+
+void qwen_conv1d_int8(float *out, const float *in,
+                      const int8_t *Wq, const float *sw, const float *bias,
+                      int in_ch, int out_ch, int length, int kernel, int dilation,
+                      int Kp, int blk) {
+    sd_conv_job_t job = {
+        .out = out, .in = in, .Wq = Wq, .sw = sw, .bias = bias,
+        .in_ch = in_ch, .out_ch = out_ch, .length = length,
+        .kernel = kernel, .dilation = dilation, .Kp = Kp, .blk = blk,
+        .n_panels = (length + SD_INT8_NC - 1) / SD_INT8_NC,
+    };
+    atomic_store(&job.next_panel, 0);
+    sd_pool_run(sd_conv1d_worker, &job);
+}
+
+/* ---------------- threaded int8 GEMM on pre-quantized activations ------ */
+/* Used by ConvTranspose: activations (transposed input) are quantized once
+ * and reused across all kernel positions. Chunks are row blocks. */
+
+typedef struct {
+    float *out; int out_ld;
+    const int8_t *Wq; const float *sw;
+    const int8_t *Xq; const float *sa;
+    int M, N, Kp, blk;
+    _Atomic int next_block;
+    int n_blocks, rows_per_block;
+} sd_gemm_job_t;
+
+static void sd_gemm_worker(void *vj) {
+    sd_gemm_job_t *j = (sd_gemm_job_t *)vj;
+    int nblk = j->Kp / j->blk;
+    for (;;) {
+        int b = atomic_fetch_add(&j->next_block, 1);
+        if (b >= j->n_blocks) break;
+        int m0 = b * j->rows_per_block;
+        int m1 = m0 + j->rows_per_block < j->M ? m0 + j->rows_per_block : j->M;
+        for (int t0 = 0; t0 < j->N; t0 += SD_INT8_NC) {
+            int nc = j->N - t0 < SD_INT8_NC ? j->N - t0 : SD_INT8_NC;
+            sd_gemm_panel(j->out + (size_t)m0 * j->out_ld, j->out_ld, m1 - m0,
+                          j->Wq + (size_t)m0 * j->Kp, j->sw + (size_t)m0 * nblk, NULL,
+                          j->Xq + (size_t)t0 * j->Kp, j->sa + (size_t)t0 * nblk,
+                          t0, nc, j->Kp, j->blk);
+        }
+    }
+}
+
+void qwen_gemm_int8(float *out, int out_ld,
+                    const int8_t *Wq, const float *sw,
+                    const int8_t *Xq, const float *sa,
+                    int M, int N, int Kp, int blk) {
+    int nt = qwen_get_threads();
+    int rpb = (M + nt * 2 - 1) / (nt * 2);
+    rpb = (rpb + 1) & ~1;               /* multiple of 2 rows */
+    if (rpb < 2) rpb = 2;
+    sd_gemm_job_t job = {
+        .out = out, .out_ld = out_ld, .Wq = Wq, .sw = sw, .Xq = Xq, .sa = sa,
+        .M = M, .N = N, .Kp = Kp, .blk = blk,
+        .rows_per_block = rpb, .n_blocks = (M + rpb - 1) / rpb,
+    };
+    atomic_store(&job.next_block, 0);
+    sd_pool_run(sd_gemm_worker, &job);
+}
+
+#else /* !__ARM_FEATURE_DOTPROD: scalar reference (unused in practice) */
+
+static float sd_scalar_dot(const int8_t *w, const float *swb,
+                           const int8_t *x, const float *sab, int Kp, int blk) {
+    int nblk = Kp / blk;
+    float acc = 0.0f;
+    for (int b = 0; b < nblk; b++) {
+        int32_t ai = 0;
+        for (int k = b * blk; k < (b + 1) * blk; k++)
+            ai += (int32_t)w[k] * x[k];
+        acc += (float)ai * swb[b] * sab[b];
+    }
+    return acc;
+}
+
+void qwen_conv1d_int8(float *out, const float *in,
+                      const int8_t *Wq, const float *sw, const float *bias,
+                      int in_ch, int out_ch, int length, int kernel, int dilation,
+                      int Kp, int blk) {
+    int K = in_ch * kernel;
+    int nblk = Kp / blk;
+    int pad_left = (kernel - 1) * dilation;
+    float *colf = (float *)aligned_malloc((size_t)K * sizeof(float));
+    int8_t *colq = (int8_t *)aligned_malloc((size_t)Kp);
+    float *sa = (float *)aligned_malloc((size_t)nblk * sizeof(float));
+    for (int t = 0; t < length; t++) {
+        for (int ic = 0; ic < in_ch; ic++)
+            for (int kk = 0; kk < kernel; kk++) {
+                int pos = t - pad_left + kk * dilation;
+                colf[ic * kernel + kk] =
+                    (pos >= 0 && pos < length) ? in[(size_t)ic * length + pos] : 0.0f;
+            }
+        qwen_int8_quant_rows(colq, sa, colf, 1, K, Kp, blk);
+        for (int m = 0; m < out_ch; m++)
+            out[(size_t)m * length + t] =
+                sd_scalar_dot(Wq + (size_t)m * Kp, sw + (size_t)m * nblk, colq, sa, Kp, blk)
+                + (bias ? bias[m] : 0.0f);
+    }
+    free(colf); free(colq); free(sa);
+}
+
+void qwen_gemm_int8(float *out, int out_ld,
+                    const int8_t *Wq, const float *sw,
+                    const int8_t *Xq, const float *sa,
+                    int M, int N, int Kp, int blk) {
+    int nblk = Kp / blk;
+    for (int m = 0; m < M; m++)
+        for (int t = 0; t < N; t++)
+            out[(size_t)m * out_ld + t] =
+                sd_scalar_dot(Wq + (size_t)m * Kp, sw + (size_t)m * nblk,
+                              Xq + (size_t)t * Kp, sa + (size_t)t * nblk, Kp, blk);
+}
+
+#endif /* __ARM_FEATURE_DOTPROD */

--- a/qwen_tts_kernels.h
+++ b/qwen_tts_kernels.h
@@ -235,6 +235,37 @@ void qwen_snake_activation(float *data, int channels, int length,
                             const float *log_alpha, const float *log_beta);
 
 /* ========================================================================
+ * INT8 SDOT conv engine (speech decoder, QWEN_SD_INT8=1)
+ * ======================================================================== */
+
+/* 1 if the SDOT int8 conv path is compiled in (ARM dotprod). */
+int qwen_sd_int8_available(void);
+
+/* K padded up to a multiple of blk (blk must be a multiple of 16). */
+int qwen_int8_kp(int K, int blk);
+
+/* Per-row, per-blk-block absmax int8 quantization: scales is [rows][Kp/blk],
+ * rows padded to Kp with zeros. */
+void qwen_int8_quant_rows(int8_t *dst, float *scales, const float *src,
+                          int rows, int K, int Kp, int blk);
+
+/* Threaded int8 causal conv1d: im2col + SDOT GEMM per column panel.
+ * Wq: [out_ch, Kp] with block scales sw [out_ch][Kp/blk] (K = in_ch*kernel,
+ * im2col order ic*kernel+kk). out: channel-first [out_ch, length], bias
+ * applied. */
+void qwen_conv1d_int8(float *out, const float *in,
+                      const int8_t *Wq, const float *sw, const float *bias,
+                      int in_ch, int out_ch, int length, int kernel, int dilation,
+                      int Kp, int blk);
+
+/* Threaded int8 GEMM on pre-quantized activations: out[M,N] (ld out_ld) =
+ * sum_b sw[m][b]*sa[t][b]*dot_b(Wq[m], Xq[t]); no bias. Rows Kp-strided. */
+void qwen_gemm_int8(float *out, int out_ld,
+                    const int8_t *Wq, const float *sw,
+                    const int8_t *Xq, const float *sa,
+                    int M, int N, int Kp, int blk);
+
+/* ========================================================================
  * Argmax / Sampling
  * ======================================================================== */
 

--- a/qwen_tts_kernels.h
+++ b/qwen_tts_kernels.h
@@ -56,8 +56,8 @@ void qwen_check_runtime_isa(void);
  * `out` may be NULL -> stderr. */
 void qwen_caps_report(void *out);
 
-/* Kernel numeric self-test: runs the dispatched matvecs (bf16/int8/argmax-int8)
- * against an f32 reference on deterministic random data. Cross-ISA correctness
+/* Kernel numeric self-test: runs the dispatched matvecs (bf16/int8/argmax-int8/
+ * q4_0/argmax-q4_0) against an f32 reference on deterministic random data. Cross-ISA correctness
  * proof for the SIMD kernels (esp. the AVX-512/VNNI paths) that does NOT depend
  * on a full-pipeline golden, so it's immune to the greedy trajectory fork.
  * `out` may be NULL -> stdout. Returns 0 on PASS, >0 = number of failed cases. */
@@ -122,11 +122,14 @@ int qwen_argmax_matvec_int8(const float *x, const int8_t *W, const float *scale,
 void qwen_quantize_bf16_to_int8(const uint16_t *src_bf16, int rows, int cols,
                                  int8_t *dst_int8, float *dst_scale);
 
-/* Q4_0 block: 32 weights packed into 18 bytes (16 nibble-pairs + fp32 scale) */
+/* Q4_0 block: 32 weights packed into 16 nibble-pair bytes + fp32 scale.
+ * DEINTERLEAVED packing: qs[i] low 4 bits = weight i, high 4 bits = weight
+ * i+16 — so SIMD unpack (and 0x0F / shr 4) yields the two 16-weight halves
+ * already in natural order (no zip), which is what the SDOT path needs. */
 #define Q4_0_BLOCK_SIZE 32
 typedef struct {
     float scale;           /* per-block scale factor */
-    uint8_t qs[16];        /* 32 nibbles: low 4 bits = even idx, high 4 bits = odd idx */
+    uint8_t qs[16];        /* 32 nibbles: lo = weights 0-15, hi = weights 16-31 */
 } q4_0_block_t;            /* 20 bytes per 32 weights */
 
 /* Quantize bf16 weight matrix to Q4_0 blocks.

--- a/qwen_tts_server.c
+++ b/qwen_tts_server.c
@@ -419,10 +419,15 @@ static void handle_tts_stream(qwen_tts_ctx_t *ctx, int fd, const char *body) {
             text, ctx->speaker_id, ctx->language_id, ctx->seed);
     double t0 = server_time_ms();
 
-    /* Set up streaming */
+    /* Set up streaming. Default 50 frames/chunk: fewer chunk boundaries mean less
+     * decoder context recompute (benchmarked ~13% faster total than 10 on 4-core N1);
+     * TTFA is unaffected because the decoder always ramps with a small first chunk. */
     stream_http_state_t state = { .fd = fd, .total_samples = 0 };
     ctx->stream = 1;
-    ctx->stream_chunk_frames = 10;
+    int chunk_frames = (int)json_extract_number(body, "chunk_frames", 50);
+    if (chunk_frames < 2)   chunk_frames = 2;
+    if (chunk_frames > 250) chunk_frames = 250;
+    ctx->stream_chunk_frames = chunk_frames;
     qwen_tts_set_audio_callback(ctx, stream_http_callback, &state);
 
     /* Send chunked response header */

--- a/qwen_tts_server.c
+++ b/qwen_tts_server.c
@@ -420,11 +420,11 @@ static void handle_tts_stream(qwen_tts_ctx_t *ctx, int fd, const char *body) {
     double t0 = server_time_ms();
 
     /* Set up streaming. Default 50 frames/chunk: fewer chunk boundaries mean less
-     * decoder context recompute (benchmarked ~13% faster total than 10 on 4-core N1);
+     * decoder context recompute (150 frames + BLAS4 + spin pool: RTF 1.7-1.8 vs 2.4 baseline on 4-core N1);
      * TTFA is unaffected because the decoder always ramps with a small first chunk. */
     stream_http_state_t state = { .fd = fd, .total_samples = 0 };
     ctx->stream = 1;
-    int chunk_frames = (int)json_extract_number(body, "chunk_frames", 50);
+    int chunk_frames = (int)json_extract_number(body, "chunk_frames", 150);
     if (chunk_frames < 2)   chunk_frames = 2;
     if (chunk_frames > 250) chunk_frames = 250;
     ctx->stream_chunk_frames = chunk_frames;

--- a/qwen_tts_speech_decoder.c
+++ b/qwen_tts_speech_decoder.c
@@ -31,6 +31,8 @@
 #include <stdlib.h>
 #include <string.h>
 #include <math.h>
+#include <time.h>
+#include <pthread.h>
 
 #ifdef __ARM_NEON
 #include <arm_neon.h>
@@ -49,6 +51,30 @@
 #endif
 #define CONV_TILE_MAX_BYTES (256 * 1024 * 1024)
 #endif
+
+/* Per-stage profiling (QWEN_SD_PROFILE=1): cumulative ms per decoder stage,
+ * printed after each conv_decoder_forward call (last print = totals). */
+static double sd_prof_ms[16];
+static const char *sd_prof_names[16] = {
+    "vq+preconv", "transformer", "out_proj", "convnext",
+    "initial_conv", "up_convT", "up_res_conv", "snake", "final_conv",
+};
+static int sd_prof_enabled(void) {
+    static int en = -1;
+    if (en < 0) { const char *e = getenv("QWEN_SD_PROFILE"); en = (e && *e && *e != '0'); }
+    return en;
+}
+static double sd_now_ms(void) {
+    struct timespec ts; clock_gettime(CLOCK_MONOTONIC, &ts);
+    return ts.tv_sec * 1000.0 + ts.tv_nsec / 1e6;
+}
+static void sd_prof_report(void) {
+    if (!sd_prof_enabled()) return;
+    fprintf(stderr, "[SD_PROF]");
+    for (int i = 0; i < 16 && sd_prof_names[i]; i++)
+        fprintf(stderr, " %s=%.0fms", sd_prof_names[i], sd_prof_ms[i]);
+    fprintf(stderr, "\n");
+}
 
 static const float *get_f32(void *ms, const char *name) {
     safetensors_file_t *sf = NULL;
@@ -101,15 +127,14 @@ static void causal_conv_transpose1d_naive(float *out, const float *in,
                                           int in_ch, int out_ch, int in_len, int out_len,
                                           int kernel, int stride) {
     memset(out, 0, (int64_t)out_ch * out_len * sizeof(float));
-    int full_len = (in_len - 1) * stride + kernel;
-    int trim_right = kernel - stride;
+    /* out_len selects the trim (see the BLAS variant). */
 
     for (int ic = 0; ic < in_ch; ic++) {
         for (int t = 0; t < in_len; t++) {
             float x = in[(int64_t)ic * in_len + t];
             for (int k = 0; k < kernel; k++) {
                 int out_pos = t * stride + k;
-                if (out_pos < full_len - trim_right && out_pos < out_len) {
+                if (out_pos < out_len) {
                     for (int oc = 0; oc < out_ch; oc++) {
                         out[(int64_t)oc * out_len + out_pos] +=
                             x * weight[((int64_t)ic * out_ch + oc) * kernel + k];
@@ -125,6 +150,97 @@ static void causal_conv_transpose1d_naive(float *out, const float *in,
     }
 }
 #endif /* !USE_BLAS */
+
+/* ------------------------------------------------------------------------
+ * INT8 conv path (QWEN_SD_INT8=1, ARM SDOT only): weights are quantized
+ * per-output-channel once on first use and cached; activations are quantized
+ * per-timestep-column inside the kernels. fp32 sgemm remains the default.
+ * ---------------------------------------------------------------------- */
+static int sd_int8_enabled(void) {
+    static int en = -1;
+    if (en < 0) {
+        const char *e = getenv("QWEN_SD_INT8");
+        en = (e && *e && *e != '0') && qwen_sd_int8_available();
+    }
+    return en;
+}
+
+/* Scale-block size along K (multiple of 16). Smaller = more accurate,
+ * slightly slower; 64 measured as the speed/quality sweet spot on N1
+ * (same RTF as 128, ~4dB better SNR). QWEN_SD_INT8_BLK overrides. */
+static int sd_int8_blk(void) {
+    static int blk = -1;
+    if (blk < 0) {
+        const char *e = getenv("QWEN_SD_INT8_BLK");
+        blk = e ? atoi(e) : 64;
+        if (blk < 16) blk = 16;
+        blk = (blk + 15) & ~15;
+    }
+    return blk;
+}
+
+/* Quantized-weight registry: keyed by (source pointer, transpose-slice k).
+ * Conv1d weights use slice -1; ConvTranspose registers one entry per kernel
+ * position (the W_k^T slice). Quantize-once, lives until process exit. */
+typedef struct {
+    const float *src;
+    int slice;
+    int8_t *q;
+    float *scales;
+    int Kp;
+} sd_wq_entry_t;
+
+#define SD_WQ_MAX 128
+static sd_wq_entry_t sd_wq[SD_WQ_MAX];
+static int sd_wq_n = 0;
+static pthread_mutex_t sd_wq_mu = PTHREAD_MUTEX_INITIALIZER;
+
+/* Conv1d weight [out_ch, in_ch*kernel]: rows already in im2col order. */
+static sd_wq_entry_t *sd_wq_get_conv(const float *w, int out_ch, int K) {
+    pthread_mutex_lock(&sd_wq_mu);
+    for (int i = 0; i < sd_wq_n; i++)
+        if (sd_wq[i].src == w && sd_wq[i].slice == -1) {
+            pthread_mutex_unlock(&sd_wq_mu);
+            return &sd_wq[i];
+        }
+    if (sd_wq_n >= SD_WQ_MAX) { pthread_mutex_unlock(&sd_wq_mu); return NULL; }
+    int blk = sd_int8_blk();
+    int Kp = qwen_int8_kp(K, blk);
+    sd_wq_entry_t *e = &sd_wq[sd_wq_n];
+    e->src = w; e->slice = -1; e->Kp = Kp;
+    e->q = (int8_t *)aligned_malloc((size_t)out_ch * Kp);
+    e->scales = (float *)aligned_malloc((size_t)out_ch * (Kp / blk) * sizeof(float));
+    qwen_int8_quant_rows(e->q, e->scales, w, out_ch, K, Kp, blk);
+    sd_wq_n++;
+    pthread_mutex_unlock(&sd_wq_mu);
+    return e;
+}
+
+/* ConvTranspose slice k: rows = out_ch, K = in_ch, from [in_ch, out_ch, kernel]. */
+static sd_wq_entry_t *sd_wq_get_convt(const float *w, int k, int in_ch, int out_ch, int kernel) {
+    pthread_mutex_lock(&sd_wq_mu);
+    for (int i = 0; i < sd_wq_n; i++)
+        if (sd_wq[i].src == w && sd_wq[i].slice == k) {
+            pthread_mutex_unlock(&sd_wq_mu);
+            return &sd_wq[i];
+        }
+    if (sd_wq_n >= SD_WQ_MAX) { pthread_mutex_unlock(&sd_wq_mu); return NULL; }
+    int blk = sd_int8_blk();
+    int Kp = qwen_int8_kp(in_ch, blk);
+    float *wk = (float *)aligned_malloc((size_t)out_ch * in_ch * sizeof(float));
+    for (int oc = 0; oc < out_ch; oc++)
+        for (int ic = 0; ic < in_ch; ic++)
+            wk[(int64_t)oc * in_ch + ic] = w[((int64_t)ic * out_ch + oc) * kernel + k];
+    sd_wq_entry_t *e = &sd_wq[sd_wq_n];
+    e->src = w; e->slice = k; e->Kp = Kp;
+    e->q = (int8_t *)aligned_malloc((size_t)out_ch * Kp);
+    e->scales = (float *)aligned_malloc((size_t)out_ch * (Kp / blk) * sizeof(float));
+    qwen_int8_quant_rows(e->q, e->scales, wk, out_ch, in_ch, Kp, blk);
+    free(wk);
+    sd_wq_n++;
+    pthread_mutex_unlock(&sd_wq_mu);
+    return e;
+}
 
 #ifdef USE_BLAS
 /* Add bias to channel-first output [channels, length] */
@@ -143,6 +259,19 @@ static void causal_conv1d_blas(float *out, const float *in,
                                const float *weight, const float *bias,
                                int in_ch, int out_ch, int length,
                                int kernel, int dilation) {
+    /* int8 only for the upsample-block res convs and the initial conv —
+     * the latent-domain convs (pre-conv 512→1024, ConvNeXt) are quality-
+     * sensitive and cheap; keep them fp32. */
+    if (sd_int8_enabled() && in_ch == out_ch && in_ch <= 768) {
+        sd_wq_entry_t *e = sd_wq_get_conv(weight, out_ch, in_ch * kernel);
+        if (e) {
+            qwen_conv1d_int8(out, in, e->q, e->scales, bias,
+                             in_ch, out_ch, length, kernel, dilation,
+                             e->Kp, sd_int8_blk());
+            return;
+        }
+    }
+
     if (kernel == 1) {
         /* k=1: weight is [out_ch, in_ch], direct matmul */
         cblas_sgemm(CblasRowMajor, CblasNoTrans, CblasNoTrans,
@@ -199,8 +328,56 @@ static void causal_conv_transpose1d_blas(float *out, const float *in,
                                          int in_ch, int out_ch, int in_len, int out_len,
                                          int kernel, int stride) {
     memset(out, 0, (int64_t)out_ch * out_len * sizeof(float));
-    int full_len = (in_len - 1) * stride + kernel;
-    int trim_right = kernel - stride;
+    /* out_len selects the trim: callers pass in_len*stride for the causal
+     * trimmed result, or (in_len-1)*stride + kernel for the full (untrimmed)
+     * scatter — the streaming path keeps the tail as overlap-add carry. */
+
+    /* ConvTranspose int8 measured SLOWER than fp32 sgemm here (small K pads
+     * poorly into scale blocks, epilogue dominates) and costs quality —
+     * kept behind QWEN_SD_INT8_CONVT=1 for experiments only. */
+    static int convt_int8 = -1;
+    if (convt_int8 < 0) {
+        const char *e = getenv("QWEN_SD_INT8_CONVT");
+        convt_int8 = (e && *e && *e != '0');
+    }
+    if (sd_int8_enabled() && convt_int8 && in_ch > out_ch) {
+        /* Quantize the transposed input once (per-timestep rows), reuse for
+         * every kernel position's W_k^T GEMM. */
+        int blk = sd_int8_blk();
+        int Kp = qwen_int8_kp(in_ch, blk);
+        float *inT = (float *)aligned_malloc((int64_t)in_len * in_ch * sizeof(float));
+        for (int t = 0; t < in_len; t++)
+            for (int ic = 0; ic < in_ch; ic++)
+                inT[(int64_t)t * in_ch + ic] = in[(int64_t)ic * in_len + t];
+        int8_t *inq = (int8_t *)aligned_malloc((size_t)in_len * Kp);
+        float *sa = (float *)aligned_malloc((size_t)in_len * (Kp / blk) * sizeof(float));
+        qwen_int8_quant_rows(inq, sa, inT, in_len, in_ch, Kp, blk);
+        free(inT);
+
+        float *rk = (float *)aligned_malloc((int64_t)out_ch * in_len * sizeof(float));
+        int ok = 1;
+        for (int k = 0; k < kernel && ok; k++) {
+            sd_wq_entry_t *e = sd_wq_get_convt(weight, k, in_ch, out_ch, kernel);
+            if (!e) { ok = 0; break; }
+            qwen_gemm_int8(rk, in_len, e->q, e->scales, inq, sa, out_ch, in_len, Kp, blk);
+
+            for (int oc = 0; oc < out_ch; oc++) {
+                const float *src = rk + (int64_t)oc * in_len;
+                float *dst = out + (int64_t)oc * out_len;
+                for (int t = 0; t < in_len; t++) {
+                    int out_pos = t * stride + k;
+                    if (out_pos < out_len)
+                        dst[out_pos] += src[t];
+                }
+            }
+        }
+        free(rk); free(inq); free(sa);
+        if (ok) {
+            conv_add_bias(out, bias, out_ch, out_len);
+            return;
+        }
+        memset(out, 0, (int64_t)out_ch * out_len * sizeof(float));
+    }
 
     /* Per-kernel-position: extract weight slice, sgemm, scatter */
     float *wk = (float *)aligned_malloc((int64_t)in_ch * out_ch * sizeof(float));
@@ -226,7 +403,7 @@ static void causal_conv_transpose1d_blas(float *out, const float *in,
             float *dst = out + (int64_t)oc * out_len;
             for (int t = 0; t < in_len; t++) {
                 int out_pos = t * stride + k;
-                if (out_pos < full_len - trim_right && out_pos < out_len)
+                if (out_pos < out_len)
                     dst[out_pos] += src[t];
             }
         }
@@ -1209,6 +1386,13 @@ void qwen_sd_stream_free(qwen_sd_stream_state_t *st) {
     }
     free(st->latent_cache); st->latent_cache = NULL;
     free(st->vq_pad); st->vq_pad = NULL;
+    free(st->cs_cn_dw_tail[0]); free(st->cs_cn_dw_tail[1]);
+    free(st->cs_init_tail);
+    free(st->cs_final_tail);
+    for (int b = 0; b < 4; b++) {
+        free(st->cs_up_carry[b]);
+        for (int r = 0; r < 3; r++) free(st->cs_res_tail[b][r]);
+    }
     memset(st, 0, sizeof(*st));
 }
 
@@ -1216,10 +1400,89 @@ void qwen_sd_stream_free(qwen_sd_stream_state_t *st) {
  * on a signal in channel-first format [latent_dim, n_frames].
  * Returns audio samples. This is the same pipeline as steps 7-10 in the
  * full decode, extracted as a helper to avoid duplication. */
+/* ConvNeXt block tail: LayerNorm (per-timestep) + pw1(1024→4096)+GELU +
+ * pw2(4096→1024), then x = residual + gamma·x. `x` holds the dwconv output
+ * [ch, len] and receives the result; `residual` is the ConvTranspose output.
+ * Shared by the one-shot and exact-streaming conv decoders (every op here is
+ * per-timestep, so chunking is transparent). */
+static void convnext_mlp(qwen_sd_convnext_t *cn, float *x, const float *residual,
+                         int cur_ch, int cur_len) {
+    /* LayerNorm (per-timestep) */
+    for (int t = 0; t < cur_len; t++) {
+        float mean = 0, var = 0;
+        for (int c = 0; c < cur_ch; c++) mean += x[(int64_t)c * cur_len + t];
+        mean /= cur_ch;
+        for (int c = 0; c < cur_ch; c++) {
+            float d = x[(int64_t)c * cur_len + t] - mean;
+            var += d * d;
+        }
+        var = 1.0f / sqrtf(var / cur_ch + 1e-5f);
+        for (int c = 0; c < cur_ch; c++) {
+            float v = (x[(int64_t)c * cur_len + t] - mean) * var;
+            x[(int64_t)c * cur_len + t] = v * cn->norm_weight[c] + cn->norm_bias[c];
+        }
+    }
+
+    /* Pointwise convs: pw1 (1024→4096, GELU), pw2 (4096→1024) */
+    int pw_dim = 4096;
+    float *pw1_out = (float *)aligned_malloc((int64_t)pw_dim * cur_len * sizeof(float));
+#ifdef USE_BLAS
+    cblas_sgemm(CblasRowMajor, CblasNoTrans, CblasNoTrans,
+                pw_dim, cur_len, cur_ch, 1.0f,
+                cn->pwconv1_weight, cur_ch, x, cur_len,
+                0.0f, pw1_out, cur_len);
+    if (cn->pwconv1_bias)
+        for (int i = 0; i < pw_dim; i++)
+            for (int t = 0; t < cur_len; t++)
+                pw1_out[(int64_t)i * cur_len + t] += cn->pwconv1_bias[i];
+#else
+    for (int o = 0; o < pw_dim; o++)
+        for (int t = 0; t < cur_len; t++) {
+            float sum = cn->pwconv1_bias ? cn->pwconv1_bias[o] : 0;
+            for (int i = 0; i < cur_ch; i++)
+                sum += cn->pwconv1_weight[(int64_t)o * cur_ch + i] * x[(int64_t)i * cur_len + t];
+            pw1_out[(int64_t)o * cur_len + t] = sum;
+        }
+#endif
+    /* Exact GELU */
+    for (int64_t i = 0; i < (int64_t)pw_dim * cur_len; i++)
+        pw1_out[i] = 0.5f * pw1_out[i] * (1.0f + erff(pw1_out[i] * 0.7071067811865476f));
+
+    /* pw2 */
+#ifdef USE_BLAS
+    cblas_sgemm(CblasRowMajor, CblasNoTrans, CblasNoTrans,
+                cur_ch, cur_len, pw_dim, 1.0f,
+                cn->pwconv2_weight, pw_dim, pw1_out, cur_len,
+                0.0f, x, cur_len);
+    if (cn->pwconv2_bias)
+        for (int o = 0; o < cur_ch; o++)
+            for (int t = 0; t < cur_len; t++)
+                x[(int64_t)o * cur_len + t] += cn->pwconv2_bias[o];
+#else
+    for (int o = 0; o < cur_ch; o++)
+        for (int t = 0; t < cur_len; t++) {
+            float sum = cn->pwconv2_bias ? cn->pwconv2_bias[o] : 0;
+            for (int i = 0; i < pw_dim; i++)
+                sum += cn->pwconv2_weight[(int64_t)o * pw_dim + i] * pw1_out[(int64_t)i * cur_len + t];
+            x[(int64_t)o * cur_len + t] = sum;
+        }
+#endif
+    free(pw1_out);
+
+    /* Gamma + residual */
+    for (int ci = 0; ci < cur_ch; ci++) {
+        float g = cn->gamma[ci];
+        for (int t = 0; t < cur_len; t++)
+            x[(int64_t)ci * cur_len + t] = residual[(int64_t)ci * cur_len + t]
+                + x[(int64_t)ci * cur_len + t] * g;
+    }
+}
+
 static int conv_decoder_forward(qwen_tts_ctx_t *ctx,
                                  float *signal, int cur_ch, int cur_len,
                                  float **audio_out, int *n_samples_out) {
     qwen_speech_decoder_t *sd = &ctx->speech_dec;
+    double sd_t0 = sd_now_ms();
 
     /* ConvNeXt upsample (2 blocks, 2x each → 4x total) */
     for (int b = 0; b < 2; b++) {
@@ -1248,78 +1511,11 @@ static int conv_decoder_forward(qwen_tts_ctx_t *ctx,
 
         float *residual = signal; signal = dw_out;
 
-        /* LayerNorm (per-timestep) */
-        for (int t = 0; t < cur_len; t++) {
-            float mean = 0, var = 0;
-            for (int c = 0; c < cur_ch; c++) mean += signal[(int64_t)c * cur_len + t];
-            mean /= cur_ch;
-            for (int c = 0; c < cur_ch; c++) {
-                float d = signal[(int64_t)c * cur_len + t] - mean;
-                var += d * d;
-            }
-            var = 1.0f / sqrtf(var / cur_ch + 1e-5f);
-            for (int c = 0; c < cur_ch; c++) {
-                float x = (signal[(int64_t)c * cur_len + t] - mean) * var;
-                signal[(int64_t)c * cur_len + t] = x * cn->norm_weight[c] + cn->norm_bias[c];
-            }
-        }
-
-        /* Pointwise convs: pw1 (1024→4096, GELU), pw2 (4096→1024) */
-        int pw_dim = 4096;
-        float *pw1_out = (float *)aligned_malloc((int64_t)pw_dim * cur_len * sizeof(float));
-#ifdef USE_BLAS
-        cblas_sgemm(CblasRowMajor, CblasNoTrans, CblasNoTrans,
-                    pw_dim, cur_len, cur_ch, 1.0f,
-                    cn->pwconv1_weight, cur_ch, signal, cur_len,
-                    0.0f, pw1_out, cur_len);
-        if (cn->pwconv1_bias)
-            for (int i = 0; i < pw_dim; i++)
-                for (int t = 0; t < cur_len; t++)
-                    pw1_out[(int64_t)i * cur_len + t] += cn->pwconv1_bias[i];
-#else
-        for (int o = 0; o < pw_dim; o++)
-            for (int t = 0; t < cur_len; t++) {
-                float sum = cn->pwconv1_bias ? cn->pwconv1_bias[o] : 0;
-                for (int i = 0; i < cur_ch; i++)
-                    sum += cn->pwconv1_weight[(int64_t)o * cur_ch + i] * signal[(int64_t)i * cur_len + t];
-                pw1_out[(int64_t)o * cur_len + t] = sum;
-            }
-#endif
-        /* Exact GELU */
-        for (int64_t i = 0; i < (int64_t)pw_dim * cur_len; i++)
-            pw1_out[i] = 0.5f * pw1_out[i] * (1.0f + erff(pw1_out[i] * 0.7071067811865476f));
-
-        /* pw2 */
-        memset(signal, 0, (int64_t)cur_ch * cur_len * sizeof(float));
-#ifdef USE_BLAS
-        cblas_sgemm(CblasRowMajor, CblasNoTrans, CblasNoTrans,
-                    cur_ch, cur_len, pw_dim, 1.0f,
-                    cn->pwconv2_weight, pw_dim, pw1_out, cur_len,
-                    0.0f, signal, cur_len);
-        if (cn->pwconv2_bias)
-            for (int o = 0; o < cur_ch; o++)
-                for (int t = 0; t < cur_len; t++)
-                    signal[(int64_t)o * cur_len + t] += cn->pwconv2_bias[o];
-#else
-        for (int o = 0; o < cur_ch; o++)
-            for (int t = 0; t < cur_len; t++) {
-                float sum = cn->pwconv2_bias ? cn->pwconv2_bias[o] : 0;
-                for (int i = 0; i < pw_dim; i++)
-                    sum += cn->pwconv2_weight[(int64_t)o * pw_dim + i] * pw1_out[(int64_t)i * cur_len + t];
-                signal[(int64_t)o * cur_len + t] = sum;
-            }
-#endif
-        free(pw1_out);
-
-        /* Gamma + residual */
-        for (int ci = 0; ci < cur_ch; ci++) {
-            float g = cn->gamma[ci];
-            for (int t = 0; t < cur_len; t++)
-                signal[(int64_t)ci * cur_len + t] = residual[(int64_t)ci * cur_len + t]
-                    + signal[(int64_t)ci * cur_len + t] * g;
-        }
+        convnext_mlp(cn, signal, residual, cur_ch, cur_len);
         free(residual);
     }
+
+    sd_prof_ms[3] += sd_now_ms() - sd_t0; sd_t0 = sd_now_ms();
 
     /* Initial conv (1024→1536, k=7, pad_left=6) */
     if (!sd->initial_conv_weight) { free(signal); return -1; }
@@ -1329,6 +1525,7 @@ static int conv_decoder_forward(qwen_tts_ctx_t *ctx,
     causal_conv1d(conv_out, signal, sd->initial_conv_weight, sd->initial_conv_bias,
                   cur_ch, new_ch, cur_len, 7, 1);
     free(signal); signal = conv_out; cur_ch = new_ch; cur_len = new_len;
+    sd_prof_ms[4] += sd_now_ms() - sd_t0;
 
     /* 4 Decoder upsample blocks */
     int up_rates[4] = {8, 5, 4, 3};
@@ -1342,14 +1539,17 @@ static int conv_decoder_forward(qwen_tts_ctx_t *ctx,
 
         if (!ub->upsample.conv_weight) { free(signal); return -1; }
 
+        double t_blk = sd_now_ms();
         if (ub->upsample.snake_alpha && ub->upsample.snake_beta)
             snake_activation(signal, cur_ch, cur_len, ub->upsample.snake_alpha, ub->upsample.snake_beta);
+        sd_prof_ms[7] += sd_now_ms() - t_blk; t_blk = sd_now_ms();
 
         int up_len = conv_transpose1d_out_len(cur_len, kernel, rate);
         float *up_out = (float *)aligned_calloc((int64_t)out_ch * up_len, sizeof(float));
         causal_conv_transpose1d(up_out, signal, ub->upsample.conv_weight, ub->upsample.conv_bias,
                                  cur_ch, out_ch, cur_len, up_len, kernel, rate);
         free(signal); signal = up_out; cur_ch = out_ch; cur_len = up_len;
+        sd_prof_ms[5] += sd_now_ms() - t_blk;
 
         int dilations[3] = {1, 3, 9};
         for (int r = 0; r < 3; r++) {
@@ -1357,23 +1557,28 @@ static int conv_decoder_forward(qwen_tts_ctx_t *ctx,
             float *res = (float *)aligned_malloc((int64_t)cur_ch * cur_len * sizeof(float));
             memcpy(res, signal, (int64_t)cur_ch * cur_len * sizeof(float));
 
+            double t_res = sd_now_ms();
             if (ub->res_blocks[r].snake1_alpha && ub->res_blocks[r].snake1_beta)
                 snake_activation(signal, cur_ch, cur_len,
                                   ub->res_blocks[r].snake1_alpha, ub->res_blocks[r].snake1_beta);
+            sd_prof_ms[7] += sd_now_ms() - t_res; t_res = sd_now_ms();
 
             float *c1_out = (float *)aligned_calloc((int64_t)cur_ch * cur_len, sizeof(float));
             causal_conv1d(c1_out, signal, ub->res_blocks[r].conv1_weight, ub->res_blocks[r].conv1_bias,
                           cur_ch, cur_ch, cur_len, 7, dil);
             memcpy(signal, c1_out, (int64_t)cur_ch * cur_len * sizeof(float));
             free(c1_out);
+            sd_prof_ms[6] += sd_now_ms() - t_res; t_res = sd_now_ms();
 
             if (ub->res_blocks[r].snake2_alpha && ub->res_blocks[r].snake2_beta)
                 snake_activation(signal, cur_ch, cur_len,
                                   ub->res_blocks[r].snake2_alpha, ub->res_blocks[r].snake2_beta);
+            sd_prof_ms[7] += sd_now_ms() - t_res; t_res = sd_now_ms();
 
             float *c2_out = (float *)aligned_calloc((int64_t)cur_ch * cur_len, sizeof(float));
             causal_conv1d(c2_out, signal, ub->res_blocks[r].conv2_weight, ub->res_blocks[r].conv2_bias,
                           cur_ch, cur_ch, cur_len, 1, 1);
+            sd_prof_ms[6] += sd_now_ms() - t_res;
 
             for (int64_t i = 0; i < (int64_t)cur_ch * cur_len; i++)
                 signal[i] = res[i] + c2_out[i];
@@ -1384,7 +1589,9 @@ static int conv_decoder_forward(qwen_tts_ctx_t *ctx,
 
     /* Final Snake + Conv (96→1, k=7) */
     if (!sd->final_snake.alpha || !sd->final_conv_weight) { free(signal); return -1; }
+    sd_t0 = sd_now_ms();
     snake_activation(signal, cur_ch, cur_len, sd->final_snake.alpha, sd->final_snake.beta);
+    sd_prof_ms[7] += sd_now_ms() - sd_t0; sd_t0 = sd_now_ms();
 
     int audio_len = conv1d_out_len(cur_len, 7, 1, 6);
     float *audio = (float *)aligned_calloc(audio_len, sizeof(float));
@@ -1405,9 +1612,282 @@ static int conv_decoder_forward(qwen_tts_ctx_t *ctx,
         if (audio[i] < -1.0f) audio[i] = -1.0f;
         if (audio[i] > 1.0f) audio[i] = 1.0f;
     }
+    sd_prof_ms[8] += sd_now_ms() - sd_t0;
+    sd_prof_report();
 
     *audio_out = audio;
     *n_samples_out = audio_len;
+    return 0;
+}
+
+/* ========================================================================
+ * Exact streaming conv decoder
+ *
+ * Identical math to conv_decoder_forward, but consumes ONLY the new latent
+ * frames, carrying per-layer causal state across calls:
+ *   - conv1d (k>1): keep the last pad_left = (k-1)·dil input columns; a
+ *     zero-initialized tail equals the causal zero padding of chunk 0.
+ *   - ConvTranspose: keep the (kernel-stride) untrimmed partial output
+ *     columns and overlap-add them into the next chunk (bias added on emit).
+ *   - snake / LayerNorm / pointwise / GELU / k=1 conv: per-timestep,
+ *     stateless.
+ * Chunked output therefore equals the one-shot decode exactly — unlike the
+ * windowed conv_rf path, which both re-decodes 20 context frames per chunk
+ * (~1.8x decoder work at 24-frame chunks) and approximates at boundaries.
+ * The windowed path is kept behind QWEN_SD_WINDOWED=1.
+ * ======================================================================== */
+
+/* Stateful causal conv1d on a chunk: prepend saved tail, convolve, emit
+ * [out_ch × len], update tail. Returns a freshly allocated output. */
+static float *cs_conv1d(const float *in, int in_ch, int out_ch, int len,
+                        int kernel, int dilation,
+                        const float *w, const float *b, float *tail) {
+    int tail_cols = (kernel - 1) * dilation;
+    int ext_len = tail_cols + len;
+    float *ext = (float *)aligned_malloc((int64_t)in_ch * ext_len * sizeof(float));
+    for (int ic = 0; ic < in_ch; ic++) {
+        memcpy(ext + (int64_t)ic * ext_len, tail + (int64_t)ic * tail_cols,
+               tail_cols * sizeof(float));
+        memcpy(ext + (int64_t)ic * ext_len + tail_cols, in + (int64_t)ic * len,
+               len * sizeof(float));
+    }
+    /* New tail = last tail_cols columns of ext (start index ext_len-tail_cols = len) */
+    for (int ic = 0; ic < in_ch; ic++)
+        memcpy(tail + (int64_t)ic * tail_cols, ext + (int64_t)ic * ext_len + len,
+               tail_cols * sizeof(float));
+
+    float *full = (float *)aligned_calloc((int64_t)out_ch * ext_len, sizeof(float));
+    causal_conv1d(full, ext, w, b, in_ch, out_ch, ext_len, kernel, dilation);
+    free(ext);
+
+    /* Emit only the chunk columns (the first tail_cols outputs re-pad with
+     * zeros and are wrong — they were already emitted by earlier chunks). */
+    float *out = (float *)aligned_malloc((int64_t)out_ch * len * sizeof(float));
+    for (int oc = 0; oc < out_ch; oc++)
+        memcpy(out + (int64_t)oc * len, full + (int64_t)oc * ext_len + tail_cols,
+               len * sizeof(float));
+    free(full);
+    return out;
+}
+
+/* Stateful causal ConvTranspose1d on a chunk: run untrimmed, overlap-add the
+ * carry into the head, emit len·stride columns (+bias), save the new
+ * (kernel-stride)-column tail as carry (bias-free partial sums).
+ * carry == NULL is allowed when kernel == stride (no cross-chunk overlap). */
+static float *cs_convt(const float *in, int in_ch, int out_ch, int len,
+                       int kernel, int stride,
+                       const float *w, const float *b, float *carry) {
+    int cs = kernel - stride;
+    int full_len = (len - 1) * stride + kernel;   /* = len·stride + cs */
+    int out_len = len * stride;
+    float *full = (float *)aligned_calloc((int64_t)out_ch * full_len, sizeof(float));
+    causal_conv_transpose1d(full, in, w, NULL, in_ch, out_ch, len, full_len,
+                            kernel, stride);
+    float *out = (float *)aligned_malloc((int64_t)out_ch * out_len * sizeof(float));
+    for (int oc = 0; oc < out_ch; oc++) {
+        float *f = full + (int64_t)oc * full_len;
+        float *o = out + (int64_t)oc * out_len;
+        if (carry) {
+            const float *cr = carry + (int64_t)oc * cs;
+            for (int i = 0; i < cs; i++) f[i] += cr[i];
+        }
+        float bb = b ? b[oc] : 0.0f;
+        for (int t = 0; t < out_len; t++) o[t] = f[t] + bb;
+        if (carry) {
+            float *cr = carry + (int64_t)oc * cs;
+            for (int i = 0; i < cs; i++) cr[i] = f[out_len + i];
+        }
+    }
+    free(full);
+    return out;
+}
+
+/* Stateful ConvNeXt depthwise conv (k=7, pad=6) with a 6-column tail. */
+static float *cs_dwconv(const float *in, int ch, int len,
+                        const float *w, const float *b, float *tail) {
+    float *out = (float *)aligned_malloc((int64_t)ch * len * sizeof(float));
+    for (int c = 0; c < ch; c++) {
+        const float *src = in + (int64_t)c * len;
+        float *tl = tail + (int64_t)c * 6;
+        float *dst = out + (int64_t)c * len;
+        float bb = b ? b[c] : 0.0f;
+        const float *wc = w + (int64_t)c * 7;
+        for (int t = 0; t < len; t++) {
+            float sum = bb;
+            for (int k = 0; k < 7; k++) {
+                int p = t - 6 + k;                 /* chunk-relative input pos */
+                sum += wc[k] * (p >= 0 ? src[p] : tl[6 + p]);
+            }
+            dst[t] = sum;
+        }
+        /* New tail = last 6 inputs of [tail | chunk] */
+        if (len >= 6) memcpy(tl, src + len - 6, 6 * sizeof(float));
+        else
+            for (int i = 0; i < 6; i++)
+                tl[i] = (i + len < 6) ? tl[i + len] : src[i + len - 6];
+    }
+    return out;
+}
+
+/* Lazily allocate (zeroed) streaming conv state. */
+static void cs_ensure_alloc(qwen_sd_stream_state_t *st) {
+    if (st->cs_alloc) return;
+    static const int up_out_ch[4] = {768, 384, 192, 96};
+    static const int up_rate[4] = {8, 5, 4, 3};
+    static const int dils[3] = {1, 3, 9};
+    st->cs_cn_dw_tail[0] = (float *)aligned_calloc(1024 * 6, sizeof(float));
+    st->cs_cn_dw_tail[1] = (float *)aligned_calloc(1024 * 6, sizeof(float));
+    st->cs_init_tail = (float *)aligned_calloc(1024 * 6, sizeof(float));
+    st->cs_final_tail = (float *)aligned_calloc(96 * 6, sizeof(float));
+    for (int b = 0; b < 4; b++) {
+        st->cs_up_carry[b] = (float *)aligned_calloc((int64_t)up_out_ch[b] * up_rate[b],
+                                                     sizeof(float));
+        for (int r = 0; r < 3; r++)
+            st->cs_res_tail[b][r] = (float *)aligned_calloc((int64_t)up_out_ch[b] * 6 * dils[r],
+                                                            sizeof(float));
+    }
+    st->cs_alloc = 1;
+}
+
+/* Streaming conv decoder: consumes `signal` [1024 × m] (takes ownership),
+ * emits exactly m·1920 samples. Mirrors conv_decoder_forward stage by
+ * stage; see the block comment above for the state discipline. */
+static int conv_decoder_forward_streaming(qwen_tts_ctx_t *ctx, float *signal, int m,
+                                          float **audio_out, int *n_samples_out) {
+    qwen_speech_decoder_t *sd = &ctx->speech_dec;
+    qwen_sd_stream_state_t *st = &ctx->sd_stream;
+    cs_ensure_alloc(st);
+    int cur_ch = 1024, cur_len = m;
+    double sd_t0 = sd_now_ms();
+
+    /* ConvNeXt upsample (2 blocks, 2x each) */
+    for (int b = 0; b < 2; b++) {
+        qwen_sd_convnext_t *cn = &sd->convnext[b];
+        if (!cn->conv_weight) { free(signal); return -1; }
+        /* k=2, s=2: no cross-chunk overlap, carry-free */
+        float *up = cs_convt(signal, cur_ch, cur_ch, cur_len, 2, 2,
+                             cn->conv_weight, cn->conv_bias, NULL);
+        free(signal); cur_len *= 2;
+        float *dw = cs_dwconv(up, cur_ch, cur_len, cn->dwconv_weight, cn->dwconv_bias,
+                              st->cs_cn_dw_tail[b]);
+        convnext_mlp(cn, dw, up, cur_ch, cur_len);
+        free(up);
+        signal = dw;
+    }
+    sd_prof_ms[3] += sd_now_ms() - sd_t0; sd_t0 = sd_now_ms();
+
+    /* Initial conv (1024→1536, k=7) */
+    if (!sd->initial_conv_weight) { free(signal); return -1; }
+    float *ic_out = cs_conv1d(signal, cur_ch, 1536, cur_len, 7, 1,
+                              sd->initial_conv_weight, sd->initial_conv_bias,
+                              st->cs_init_tail);
+    free(signal); signal = ic_out; cur_ch = 1536;
+    sd_prof_ms[4] += sd_now_ms() - sd_t0;
+
+    /* 4 Decoder upsample blocks */
+    int up_rates[4] = {8, 5, 4, 3};
+    int out_channels[4] = {768, 384, 192, 96};
+
+    for (int b = 0; b < 4; b++) {
+        qwen_sd_upsample_block_t *ub = &sd->upsample_blocks[b];
+        int rate = up_rates[b];
+        int kernel = rate * 2;
+        int out_ch = out_channels[b];
+
+        if (!ub->upsample.conv_weight) { free(signal); return -1; }
+
+        double t_blk = sd_now_ms();
+        if (ub->upsample.snake_alpha && ub->upsample.snake_beta)
+            snake_activation(signal, cur_ch, cur_len, ub->upsample.snake_alpha, ub->upsample.snake_beta);
+        sd_prof_ms[7] += sd_now_ms() - t_blk; t_blk = sd_now_ms();
+
+        float *up_out = cs_convt(signal, cur_ch, out_ch, cur_len, kernel, rate,
+                                 ub->upsample.conv_weight, ub->upsample.conv_bias,
+                                 st->cs_up_carry[b]);
+        free(signal); signal = up_out; cur_ch = out_ch; cur_len *= rate;
+        sd_prof_ms[5] += sd_now_ms() - t_blk;
+
+        int dilations[3] = {1, 3, 9};
+        for (int r = 0; r < 3; r++) {
+            int dil = dilations[r];
+            float *res = (float *)aligned_malloc((int64_t)cur_ch * cur_len * sizeof(float));
+            memcpy(res, signal, (int64_t)cur_ch * cur_len * sizeof(float));
+
+            double t_res = sd_now_ms();
+            if (ub->res_blocks[r].snake1_alpha && ub->res_blocks[r].snake1_beta)
+                snake_activation(signal, cur_ch, cur_len,
+                                  ub->res_blocks[r].snake1_alpha, ub->res_blocks[r].snake1_beta);
+            sd_prof_ms[7] += sd_now_ms() - t_res; t_res = sd_now_ms();
+
+            float *c1_out = cs_conv1d(signal, cur_ch, cur_ch, cur_len, 7, dil,
+                                      ub->res_blocks[r].conv1_weight, ub->res_blocks[r].conv1_bias,
+                                      st->cs_res_tail[b][r]);
+            free(signal); signal = c1_out;
+            sd_prof_ms[6] += sd_now_ms() - t_res; t_res = sd_now_ms();
+
+            if (ub->res_blocks[r].snake2_alpha && ub->res_blocks[r].snake2_beta)
+                snake_activation(signal, cur_ch, cur_len,
+                                  ub->res_blocks[r].snake2_alpha, ub->res_blocks[r].snake2_beta);
+            sd_prof_ms[7] += sd_now_ms() - t_res; t_res = sd_now_ms();
+
+            /* conv2 is k=1: stateless */
+            float *c2_out = (float *)aligned_calloc((int64_t)cur_ch * cur_len, sizeof(float));
+            causal_conv1d(c2_out, signal, ub->res_blocks[r].conv2_weight, ub->res_blocks[r].conv2_bias,
+                          cur_ch, cur_ch, cur_len, 1, 1);
+            sd_prof_ms[6] += sd_now_ms() - t_res;
+
+            for (int64_t i = 0; i < (int64_t)cur_ch * cur_len; i++)
+                signal[i] = res[i] + c2_out[i];
+            free(c2_out);
+            free(res);
+        }
+    }
+
+    /* Final Snake + Conv (96→1, k=7) with a 6-column input tail */
+    if (!sd->final_snake.alpha || !sd->final_conv_weight) { free(signal); return -1; }
+    sd_t0 = sd_now_ms();
+    snake_activation(signal, cur_ch, cur_len, sd->final_snake.alpha, sd->final_snake.beta);
+    sd_prof_ms[7] += sd_now_ms() - sd_t0; sd_t0 = sd_now_ms();
+
+    float *audio = (float *)aligned_calloc(cur_len, sizeof(float));
+    {
+        float *tl = st->cs_final_tail;   /* [96 × 6] */
+        if (sd->final_conv_bias)
+            for (int t = 0; t < cur_len; t++) audio[t] = sd->final_conv_bias[0];
+        for (int ic = 0; ic < cur_ch; ic++) {
+            const float *src = signal + (int64_t)ic * cur_len;
+            const float *wc = sd->final_conv_weight + (int64_t)ic * 7;
+            const float *tc = tl + (int64_t)ic * 6;
+            for (int t = 0; t < cur_len; t++) {
+                float sum = 0;
+                for (int k = 0; k < 7; k++) {
+                    int p = t - 6 + k;
+                    sum += wc[k] * (p >= 0 ? src[p] : tc[6 + p]);
+                }
+                audio[t] += sum;
+            }
+        }
+        /* Update tail with the last 6 (snake-activated) inputs */
+        for (int ic = 0; ic < cur_ch; ic++) {
+            float *tc = tl + (int64_t)ic * 6;
+            const float *src = signal + (int64_t)ic * cur_len;
+            if (cur_len >= 6) memcpy(tc, src + cur_len - 6, 6 * sizeof(float));
+            else
+                for (int i = 0; i < 6; i++)
+                    tc[i] = (i + cur_len < 6) ? tc[i + cur_len] : src[i + cur_len - 6];
+        }
+    }
+    free(signal);
+
+    for (int i = 0; i < cur_len; i++) {
+        if (audio[i] < -1.0f) audio[i] = -1.0f;
+        if (audio[i] > 1.0f) audio[i] = 1.0f;
+    }
+    sd_prof_ms[8] += sd_now_ms() - sd_t0;
+    sd_prof_report();
+
+    *audio_out = audio;
+    *n_samples_out = cur_len;
     return 0;
 }
 
@@ -1432,6 +1912,8 @@ int qwen_speech_decoder_decode_streaming(qwen_tts_ctx_t *ctx,
     int window = 72;
     float eps = c->dec_rms_norm_eps;
     int half_hd = head_dim / 2;
+
+    double sd_st = sd_now_ms();
 
     /* === Step 1: VQ dequant for new frames only === */
     /* Output: vq_out row-major [new_frames, 512] */
@@ -1545,6 +2027,8 @@ int qwen_speech_decoder_decode_streaming(qwen_tts_ctx_t *ctx,
     }
     free(pre_conv_out);
 #endif
+
+    sd_prof_ms[0] += sd_now_ms() - sd_st; sd_st = sd_now_ms();
 
     /* === Step 4: Pre-transformer with KV cache === */
     /* Ensure KV cache is allocated */
@@ -1764,6 +2248,7 @@ int qwen_speech_decoder_decode_streaming(qwen_tts_ctx_t *ctx,
     st->kv_len += new_frames;
 
     free(q); free(new_k); free(new_v); free(x_norm); free(attn_out);
+    sd_prof_ms[1] += sd_now_ms() - sd_st; sd_st = sd_now_ms();
 
     /* === Step 5: Final RMSNorm + Output proj (512→1024) on new frames === */
     if (sd->final_norm_weight) {
@@ -1802,8 +2287,36 @@ int qwen_speech_decoder_decode_streaming(qwen_tts_ctx_t *ctx,
 #endif
     st->latent_frames += new_frames;
     free(hidden);
+    sd_prof_ms[2] += sd_now_ms() - sd_st;
 
-    /* === Step 6: Windowed conv decoder === */
+    /* === Step 6: conv decoder on the new frames === */
+    /* Default: exact streaming conv state (no context re-decode, chunked
+     * output == one-shot decode). QWEN_SD_WINDOWED=1 restores the old
+     * windowed conv_rf approximation. */
+    static int use_windowed = -1;
+    if (use_windowed < 0) {
+        const char *e = getenv("QWEN_SD_WINDOWED");
+        use_windowed = (e && *e && *e != '0');
+    }
+    if (!use_windowed) {
+        float *sig = (float *)aligned_malloc((int64_t)latent_dim * new_frames * sizeof(float));
+        const float *lsrc = st->latent_cache + (int64_t)(st->latent_frames - new_frames) * latent_dim;
+        for (int f = 0; f < new_frames; f++)
+            for (int d = 0; d < latent_dim; d++)
+                sig[(int64_t)d * new_frames + f] = lsrc[(int64_t)f * latent_dim + d];
+
+        float *audio = NULL;
+        int ns = 0;
+        int ret = conv_decoder_forward_streaming(ctx, sig, new_frames, &audio, &ns);
+        if (ret != 0) return ret;
+
+        st->frames_decoded += new_frames;
+        st->samples_produced += ns;
+        *audio_out = audio;
+        *n_samples = ns;
+        return 0;
+    }
+
     /* Take last (RF + new_frames) from latent cache, or all if fewer */
     int conv_rf = QWEN_SD_STREAM_CONV_RF;
     int window_frames = st->latent_frames;

--- a/qwen_tts_thread.c
+++ b/qwen_tts_thread.c
@@ -168,7 +168,19 @@ int qwen_parallel_is_reentrant(void) { return 0; }
  * worker is actually asleep. Chunk claiming stays dynamic, so outputs are
  * bit-identical to the sleeping pool. */
 
-#define QWEN_POOL_SPIN 8192   /* yield iterations (~40-80us) before sleeping */
+#define QWEN_POOL_SPIN_DEFAULT 8192 /* yield iterations (~40-80us) before sleeping */
+/* Spin budget before a worker parks on the condvar. Overridable with
+ * QWEN_POOL_SPIN: lower it when synthesis overlaps other CPU-heavy work
+ * (e.g. the streaming decoder) so idle spin does not steal those cores. */
+static int qwen_pool_spin(void) {
+    static int v = -1;
+    if (v < 0) {
+        const char *e = getenv("QWEN_POOL_SPIN");
+        v = e ? atoi(e) : QWEN_POOL_SPIN_DEFAULT;
+        if (v < 1) v = 1;
+    }
+    return v;
+}
 
 typedef struct {
     qwen_task_fn fn;
@@ -215,7 +227,7 @@ static void *worker_main(void *arg) {
         int spins = 0;
         while (!atomic_load_explicit(&P.stop, memory_order_relaxed) &&
                atomic_load_explicit(&P.generation, memory_order_acquire) == seen) {
-            if (++spins >= QWEN_POOL_SPIN) {
+            if (++spins >= qwen_pool_spin()) {
                 /* Sleep phase. Re-check generation under the mutex before
                  * waiting so a dispatch between our last spin check and the
                  * cond_wait cannot be missed. */
@@ -306,7 +318,7 @@ void qwen_parallel(size_t nt, qwen_task_fn fn, void *ctx) {
     /* Completion: spin briefly, then sleep. */
     int spins = 0;
     while (atomic_load_explicit(&P.completed, memory_order_acquire) != P.nworkers) {
-        if (++spins >= QWEN_POOL_SPIN) {
+        if (++spins >= qwen_pool_spin()) {
             pthread_mutex_lock(&P.mtx);
             atomic_store(&P.main_sleeping, 1);
             while (atomic_load(&P.completed) != P.nworkers)

--- a/qwen_tts_thread.c
+++ b/qwen_tts_thread.c
@@ -160,6 +160,16 @@ int qwen_parallel_is_reentrant(void) { return 0; }
 #include <stdatomic.h>
 #include <stdlib.h>
 
+/* Hybrid spin-then-sleep pool. During the token loop, qwen_parallel dispatches
+ * arrive back-to-back (hundreds per frame), and pure condvar handoff costs a
+ * futex round-trip per dispatch — measured ~7300 futex calls per generated
+ * frame on a 4-core Neoverse-N1. Workers therefore spin briefly for the next
+ * job before sleeping, and the dispatcher only touches the condvar when a
+ * worker is actually asleep. Chunk claiming stays dynamic, so outputs are
+ * bit-identical to the sleeping pool. */
+
+#define QWEN_POOL_SPIN 8192   /* yield iterations (~40-80us) before sleeping */
+
 typedef struct {
     qwen_task_fn fn;
     void *ctx;
@@ -171,14 +181,24 @@ static struct {
     pthread_t *threads;
     int nworkers;
     pthread_mutex_t mtx;
-    pthread_cond_t wake;       /* workers wait for a new job */
-    pthread_cond_t complete;   /* main waits for job completion */
+    pthread_cond_t wake;       /* workers wait for a new job (sleep phase only) */
+    pthread_cond_t complete;   /* main waits for job completion (sleep phase only) */
     qwen_job_t *job;
-    unsigned long generation;  /* bumped per dispatch; workers compare to detect new work */
-    int completed;             /* workers that finished the current job */
-    int stop;
+    _Atomic unsigned long generation;  /* bumped per dispatch (release) */
+    _Atomic int completed;     /* workers that finished the current job */
+    _Atomic int sleeping;      /* workers inside the condvar sleep phase */
+    _Atomic int main_sleeping; /* main is sleeping in the completion wait */
+    _Atomic int stop;
 } P;
 static int g_inited = 0;
+
+static inline void qwen_cpu_relax(void) {
+#if defined(__aarch64__) || defined(__arm__)
+    __asm__ __volatile__("yield");
+#elif defined(__x86_64__) || defined(__i386__)
+    __asm__ __volatile__("pause");
+#endif
+}
 
 static void run_chunks(qwen_job_t *job) {
     size_t i;
@@ -189,28 +209,44 @@ static void run_chunks(qwen_job_t *job) {
 static void *worker_main(void *arg) {
     (void)arg;
     qwen_ftz_on();             /* per-thread FTZ (int8 denormals) — set once */
-    pthread_mutex_lock(&P.mtx);
-    unsigned long seen = P.generation;
+    unsigned long seen = atomic_load(&P.generation);
     for (;;) {
-        while (!P.stop && P.generation == seen)
-            pthread_cond_wait(&P.wake, &P.mtx);
-        if (P.stop) break;
-        seen = P.generation;
-        qwen_job_t *job = P.job;
-        pthread_mutex_unlock(&P.mtx);
+        /* Spin phase: catch back-to-back dispatches without a futex trip. */
+        int spins = 0;
+        while (!atomic_load_explicit(&P.stop, memory_order_relaxed) &&
+               atomic_load_explicit(&P.generation, memory_order_acquire) == seen) {
+            if (++spins >= QWEN_POOL_SPIN) {
+                /* Sleep phase. Re-check generation under the mutex before
+                 * waiting so a dispatch between our last spin check and the
+                 * cond_wait cannot be missed. */
+                pthread_mutex_lock(&P.mtx);
+                atomic_fetch_add(&P.sleeping, 1);
+                while (!atomic_load(&P.stop) && atomic_load(&P.generation) == seen)
+                    pthread_cond_wait(&P.wake, &P.mtx);
+                atomic_fetch_sub(&P.sleeping, 1);
+                pthread_mutex_unlock(&P.mtx);
+                break;
+            }
+            qwen_cpu_relax();
+        }
+        if (atomic_load(&P.stop)) break;
+        seen = atomic_load_explicit(&P.generation, memory_order_acquire);
+        qwen_job_t *job = P.job;   /* published before the generation bump */
         if (job) run_chunks(job);
-        pthread_mutex_lock(&P.mtx);
-        if (++P.completed == P.nworkers)
+        if (atomic_fetch_add(&P.completed, 1) + 1 == P.nworkers &&
+            atomic_load(&P.main_sleeping)) {
+            pthread_mutex_lock(&P.mtx);
             pthread_cond_signal(&P.complete);
+            pthread_mutex_unlock(&P.mtx);
+        }
     }
-    pthread_mutex_unlock(&P.mtx);
     return NULL;
 }
 
 void qwen_threadpool_stop(void) {
     if (!g_inited || !P.threads) return;
     pthread_mutex_lock(&P.mtx);
-    P.stop = 1;
+    atomic_store(&P.stop, 1);
     pthread_cond_broadcast(&P.wake);
     pthread_mutex_unlock(&P.mtx);
     for (int i = 0; i < P.nworkers; i++)
@@ -218,7 +254,7 @@ void qwen_threadpool_stop(void) {
     free(P.threads);
     P.threads = NULL;
     P.nworkers = 0;
-    P.stop = 0;
+    atomic_store(&P.stop, 0);
 }
 
 void qwen_threadpool_start(int n_threads) {
@@ -227,7 +263,11 @@ void qwen_threadpool_start(int n_threads) {
         pthread_mutex_init(&P.mtx, NULL);
         pthread_cond_init(&P.wake, NULL);
         pthread_cond_init(&P.complete, NULL);
-        P.generation = 0;
+        atomic_init(&P.generation, 0);
+        atomic_init(&P.completed, 0);
+        atomic_init(&P.sleeping, 0);
+        atomic_init(&P.main_sleeping, 0);
+        atomic_init(&P.stop, 0);
         g_inited = 1;
     }
     if (want == P.nworkers) return;
@@ -249,20 +289,35 @@ void qwen_parallel(size_t nt, qwen_task_fn fn, void *ctx) {
     job.fn = fn; job.ctx = ctx; job.nt = nt;
     atomic_init(&job.next, 0);
 
-    pthread_mutex_lock(&P.mtx);
     P.job = &job;
-    P.completed = 0;
-    P.generation++;
-    pthread_cond_broadcast(&P.wake);
-    pthread_mutex_unlock(&P.mtx);
+    atomic_store(&P.completed, 0);
+    atomic_fetch_add_explicit(&P.generation, 1, memory_order_release);
+    /* Only pay the futex wake if someone is actually asleep. A worker that was
+     * about to sleep re-checks the generation under the mutex, so it cannot
+     * miss this dispatch even if we skip the broadcast here. */
+    if (atomic_load(&P.sleeping) > 0) {
+        pthread_mutex_lock(&P.mtx);
+        pthread_cond_broadcast(&P.wake);
+        pthread_mutex_unlock(&P.mtx);
+    }
 
     run_chunks(&job);              /* main participates */
 
-    pthread_mutex_lock(&P.mtx);
-    while (P.completed != P.nworkers)
-        pthread_cond_wait(&P.complete, &P.mtx);
+    /* Completion: spin briefly, then sleep. */
+    int spins = 0;
+    while (atomic_load_explicit(&P.completed, memory_order_acquire) != P.nworkers) {
+        if (++spins >= QWEN_POOL_SPIN) {
+            pthread_mutex_lock(&P.mtx);
+            atomic_store(&P.main_sleeping, 1);
+            while (atomic_load(&P.completed) != P.nworkers)
+                pthread_cond_wait(&P.complete, &P.mtx);
+            atomic_store(&P.main_sleeping, 0);
+            pthread_mutex_unlock(&P.mtx);
+            break;
+        }
+        qwen_cpu_relax();
+    }
     P.job = NULL;
-    pthread_mutex_unlock(&P.mtx);
 }
 
 /* Single global job slot → NOT safe to submit from two threads at once. */


### PR DESCRIPTION
This series takes streaming synthesis from RTF ~2.2 to ~1.3 (0.6B, 4-core Oracle A1 / Neoverse-N1, `-j4`), with first-audio unchanged at ~1s. Four commits, each independently useful; merges clean against current main (common base a4f6337).

## What's in it

**1. `feat(server): stream chunk_frames JSON param` (cae8fff)**
Server streaming chunk size becomes a per-request JSON param with a saner default.

**2. `perf: hybrid spin-then-sleep thread pool` (91a09f1)**
The POSIX pool previously paid a futex round-trip per dispatch — measured ~7300 futex calls per generated frame. Workers now spin briefly (`yield` instruction, bounded, env-tunable via `QWEN_POOL_SPIN`) before parking on the condvar. Outputs bit-identical.

**3. `perf: NEON SDOT kernel for Q4_0 matvec` (10fa776)**
Deinterleaved nibble packing + `vdotq_s32`: int4 goes from 50.7+139 ms/f (talker+CP) to ~18.7+43.2, and now beats int8 end-to-end on ARM. `QWEN_NO_SDOT=1` reproduces the old path bit-identically.

**4. `perf: speech decoder 2.5x` (a471840)** — the big one; the conv vocoder was ~50% of wall time:
- **NEON polynomial sine for snake activations** (period-π reduction; squaring makes the reduced sign irrelevant) + threaded rows: 1209ms → 90ms on a 7.4s clip, ≤1 int16 LSB vs libm.
- **INT8-SDOT im2col GEMM for the upsample res-block convs**, opt-in `QWEN_SD_INT8=1`. Per-64-element block scales on *both* operands (Q8_0-style — a single per-column scale measures only ~17dB SNR because large channels crush small ones; block scales restore ~38dB overall / 26dB worst 4k-segment, inaudible in A/B). Runs on a small dedicated pool since the main pool isn't reentrant and is owned by the generation thread. Interesting negative result kept out of the default path: int8 ConvTranspose is *slower* than fp32 sgemm here (small K, epilogue-dominated) — gated behind `QWEN_SD_INT8_CONVT=1`.
- **Exact streaming conv state**: each conv1d carries its `pad_left` input tail and each ConvTranspose its `(kernel-stride)` overlap-add carry between chunks, replacing the windowed `conv_rf=20` re-decode (~1.8× decoder work at 24-frame chunks). Chunked output is now **byte-identical for any chunk pattern** (verified md5 across chunks 2/7/24/150, seed 42) and equals the one-shot decode. Old path kept via `QWEN_SD_WINDOWED=1`.
- `QWEN_SD_PROFILE=1` prints per-stage decoder timers.

## Numbers (0.6B, `--int4 -j4`, seed 42, 7.4s clip, 4-core N1)

| Scenario | before | after |
|---|---|---|
| stream, 24-frame chunks | 2.21 | **1.34** (`QWEN_SD_INT8=1`) / 1.62 (fp32 decoder) |
| file mode, 150-frame chunks | 1.59 | **1.21** |
| 24s clip, either mode | ~2.3 | **~1.36** |

`make test-small` and `--self-test` pass (1.7B not re-tested — no model on the box; happy to rerun anything you'd like).

Found while profiling: the Code Predictor is DRAM-bandwidth-bound on this class of hardware (5 layers × 15 sequential passes ≈ 585MB of int4 weights re-streamed per frame), so ~1.05 RTF is the 4-core floor regardless of kernels — noting it here so nobody burns time hunting for compute wins there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
