### PR TITLE
fix #19: fused GPU Talker replayed the previous request in server mode

### DIFF
--- a/qwen_tts.c
+++ b/qwen_tts.c
@@ -1352,6 +1352,27 @@ int qwen_tts_generate(qwen_tts_ctx_t *ctx, const char *text, float **out_samples
      * the sequential path and correctly repopulate dec_x at the last position. */
     if (delta_start >= prefill_len) delta_start = 0;
 
+#if defined(QWEN_HAVE_CUDA) || defined(QWEN_HAVE_METAL)
+    /* Issue #19 (part 2): fused GPU Talker + emotion steering. Steered steps run on the
+     * CPU path and read the HOST KV, but a fused delta-prefill writes the device KV only,
+     * so host rows [delta_start, prefill_len) may be stale from an earlier request. A
+     * steered decode would then attend to the previous request's text. Force a full fresh
+     * prefill (host + device KV both repopulated) whenever this request will steer. */
+    {
+        extern void *g_gpu_fused_owner;
+        int fused_owner = 0;
+#ifdef QWEN_HAVE_CUDA
+        { extern void *g_cuda_talker_state;
+          if (g_cuda_talker_state && ctx == g_gpu_fused_owner) fused_owner = 1; }
+#endif
+#ifdef QWEN_HAVE_METAL
+        { extern void *g_metal_talker_state;
+          if (g_metal_talker_state && ctx == g_gpu_fused_owner) fused_owner = 1; }
+#endif
+        if (fused_owner && ctx->ml_steer && ctx->ml_steer_weight != 0.0f) delta_start = 0;
+    }
+#endif
+
     /* Reset KV cache to the reusable prefix length */
     ctx->kv_len = delta_start;
 
@@ -1395,12 +1416,18 @@ int qwen_tts_generate(qwen_tts_ctx_t *ctx, const char *text, float **out_samples
         }
     }
 #ifdef QWEN_HAVE_CUDA
-    /* Fused GPU Talker: the CPU batched prefill populated the host bf16 KV; upload it to the
-     * device cache once so the fused decode steps (which read the device KV) see the prompt. */
+    /* Fused GPU Talker KV sync (issue #19). The device KV is the source of truth in fused mode:
+     *  - delta_start == 0 (full CPU batched prefill): host kv_cache_k/v is freshly populated
+     *    by qwen_talker_prefill → mirror it to the device once.
+     *  - delta_start > 0 (server delta-reuse): the new tokens were stepped through the fused
+     *    GPU step, which writes the device KV DIRECTLY and skips the host KV. The matching
+     *    prefix [0, delta_start) is still valid on the device from the previous request, so
+     *    the device KV is ALREADY correct — uploading here would clobber it with the stale
+     *    host KV (the previous request's text) and make the model replay the old prompt. */
     {
         extern void *g_cuda_talker_state, *g_gpu_fused_owner;
         extern void qwen_cuda_talker_upload_kv(void *, qwen_tts_ctx_t *, int);
-        if (g_cuda_talker_state && ctx == g_gpu_fused_owner &&
+        if (g_cuda_talker_state && ctx == g_gpu_fused_owner && delta_start == 0 &&
             !(ctx->ml_steer && ctx->ml_steer_w_eff != 0.0f))
             qwen_cuda_talker_upload_kv(g_cuda_talker_state, ctx, ctx->kv_len);
     }
@@ -1409,7 +1436,7 @@ int qwen_tts_generate(qwen_tts_ctx_t *ctx, const char *text, float **out_samples
     {
         extern void *g_metal_talker_state, *g_gpu_fused_owner;
         extern void qwen_metal_talker_upload_kv(void *, qwen_tts_ctx_t *, int);
-        if (g_metal_talker_state && ctx == g_gpu_fused_owner &&
+        if (g_metal_talker_state && ctx == g_gpu_fused_owner && delta_start == 0 &&
             !(ctx->ml_steer && ctx->ml_steer_w_eff != 0.0f))
             qwen_metal_talker_upload_kv(g_metal_talker_state, ctx, ctx->kv_len);
     }

--- a/qwen_tts_cuda_talker.cu
+++ b/qwen_tts_cuda_talker.cu
@@ -411,6 +411,16 @@ extern "C" void qwen_cuda_talker_step(void *st, const float *embed, float *hidde
     CK(cudaMemcpy(hidden_out,s->xn,H*sizeof(float),cudaMemcpyDeviceToHost));
 }
 
+/* Last stepped token's pre-final-norm residual (s->x, stable after the step's sync).
+ * qwen_talker_step uses it to refresh ctx->dec_x, which the fused step otherwise never
+ * touches: the generation loop seeds last_hidden = rms_norm(dec_x, talker_norm) after
+ * prefill, and a stale dec_x from the previous request corrupts the first frame in the
+ * server delta-reuse path (issue #19). */
+extern "C" void qwen_cuda_talker_get_dec_x(void *state, float *out) {
+    cuda_talker_t *s=(cuda_talker_t*)state;
+    if (s && out) CK(cudaMemcpy(out, s->x, (size_t)s->hidden*sizeof(float), cudaMemcpyDeviceToHost));
+}
+
 extern "C" void qwen_cuda_talker_upload_kv(void *state, qwen_tts_ctx_t *ctx, int prefill_len) {
     cuda_talker_t *s=(cuda_talker_t*)state; if(!s||prefill_len<=0) return;
     int kvd=s->kv_dim, L=s->n_layers, kvm=s->kv_max;

--- a/qwen_tts_metal.m
+++ b/qwen_tts_metal.m
@@ -1704,6 +1704,17 @@ void qwen_metal_talker_step(void *st, const float *embed, float *hidden_out, int
     }
 }
 
+/* Last stepped token's pre-final-norm residual (xb, stable after waitUntilCompleted).
+ * qwen_talker_step uses it to refresh ctx->dec_x, which the fused step otherwise never
+ * touches (the delta-reuse server path would seed the first frame from a stale dec_x —
+ * issue #19). Shared buffer → plain memcpy from .contents. */
+void qwen_metal_talker_get_dec_x(void *st, float *out) {
+    qwen_metal_talker_t *s = st; if (!s || !out) return;
+    @autoreleasepool {
+        memcpy(out, ((__bridge id<MTLBuffer>)s->xb).contents, (size_t)s->H*sizeof(float));
+    }
+}
+
 /* Seed the device KV from the CPU batched prefill (ctx->kv_cache_{k,v} bf16), so the fused
  * decode steps attend to the prompt. Mirrors qwen_cuda_talker_upload_kv. bf16->f32 = bits<<16
  * (= the bf16-truncated f32 kv_store also writes). Shared buffers → write .contents directly. */

--- a/qwen_tts_talker.c
+++ b/qwen_tts_talker.c
@@ -503,11 +503,13 @@ void *g_cuda_talker_batch_state = NULL;
 void *g_metal_talker_state = NULL;
 void *g_metal_talker_batch_state = NULL;   /* batched fused Talker step (server throughput) */
 extern void qwen_metal_talker_step(void *state, const float *embed, float *hidden_out, int pos);
+extern void qwen_metal_talker_get_dec_x(void *state, float *out);
 extern void qwen_metal_talker_batch_step(void *state, const float *embeds, const int *pos_arr, float *hidden_out);
 #endif
 #ifdef QWEN_HAVE_CUDA
 extern void qwen_cuda_talker_batch_step(void *state, const float *embeds, const int *pos_arr, float *hidden_out);
 extern void qwen_cuda_talker_step(void *state, const float *embed, float *hidden_out, int pos);
+extern void qwen_cuda_talker_get_dec_x(void *state, float *out);
 #endif
 
 int qwen_talker_step(qwen_tts_ctx_t *ctx, float *embed, float *hidden_out) {
@@ -519,18 +521,29 @@ int qwen_talker_step(qwen_tts_ctx_t *ctx, float *embed, float *hidden_out) {
     int pos = ctx->kv_len;
     float eps = c->rms_norm_eps;
 
+    /* Fused-vs-CPU dispatch is per-REQUEST (ml_steer_weight), not per-frame (w_eff):
+     * mixing fused steps (device KV only) and CPU steered steps (host KV only) inside one
+     * request leaves each cache missing the other side's rows — a pulse schedule
+     * (--ml-frames N) would read garbage after the pulse. A steered request runs fully on
+     * the CPU path (the fused step doesn't apply ml_steer yet); qwen_tts_generate forces a
+     * full prefill for it so the host KV is coherent (issue #19 part 2). */
 #ifdef QWEN_HAVE_CUDA
     if (g_cuda_talker_state && ctx == g_gpu_fused_owner &&
-        !(ctx->ml_steer && ctx->ml_steer_w_eff != 0.0f)) {
+        !(ctx->ml_steer && ctx->ml_steer_weight != 0.0f)) {
         qwen_cuda_talker_step(g_cuda_talker_state, embed, hidden_out, pos);
+        /* The fused step skips the host state; refresh ctx->dec_x from the device residual
+         * so the prefill→decode handoff (last_hidden = rms_norm(dec_x, talker_norm)) stays
+         * correct across server delta-reuse requests and streaming chunk seeds (issue #19). */
+        qwen_cuda_talker_get_dec_x(g_cuda_talker_state, ctx->dec_x);
         ctx->kv_len = pos + 1;
         return 0;
     }
 #endif
 #ifdef QWEN_HAVE_METAL
     if (g_metal_talker_state && ctx == g_gpu_fused_owner &&
-        !(ctx->ml_steer && ctx->ml_steer_w_eff != 0.0f)) {
+        !(ctx->ml_steer && ctx->ml_steer_weight != 0.0f)) {
         qwen_metal_talker_step(g_metal_talker_state, embed, hidden_out, pos);
+        qwen_metal_talker_get_dec_x(g_metal_talker_state, ctx->dec_x);
         ctx->kv_len = pos + 1;
         return 0;
     }


### PR DESCRIPTION
Fixes #19.

In fused mode (`QWEN_CUDA_FUSED_TALKER=1` / `QWEN_METAL_FUSED_TALKER=1`) with `--serve`, every request after the first replayed the previous request's text. The server delta-prefill stepped the new text tokens through the fused GPU step (device KV written directly, host KV + `dec_x` left stale), then the unconditional `qwen_*_talker_upload_kv` clobbered the correct device KV with the stale host KV — the model attended to the old prompt and replayed it.

**Fix (3 parts):**
1. Host→device KV upload only on full prefill (`delta_start == 0`) — in the delta path the device KV is already correct.
2. `ctx->dec_x` refreshed from the device residual after each fused step (frame-0 seed + streaming chunk handoff).
3. Emotion steering (missed by the patch proposed in the issue, but confirmed replaying pre-fix): steered decode runs on the CPU path and reads the *host* KV → steered requests force a full fresh prefill, and fused/CPU dispatch is now per-request (`ml_steer_weight`) instead of per-frame (`w_eff`), so pulse schedules can't mix device-only and host-only KV rows.

**Validation:**
- Pre-fix A/B on Metal (M1): bug reproduced exactly — requests 2, 3 (joy) and 4 all replay request 1 (whisper-verified).
- With fix: 6 successive server requests (neutral, neutral, joy, neutral, sad, repeat-of-request-1) on **CUDA (GB10)**, **Metal (M1)** and **pure CPU** → 18/18 whisper transcripts correct + ear check passed.
- `make test-all` PASS (0.6B + 1.7B golden mel-corr 1.0, kernel self-test, server reproducibility ±1 LSB) — CPU path unchanged.
- CUDA `--gpu-selftest-talker`: argmax CPU==GPU every step (the ~6e-3 RMS-rel is the known pre-existing fused fp fork, not a regression).

Thanks @dynameow for the report, the audio repro and the diagnosis groundwork.